### PR TITLE
Redact errors

### DIFF
--- a/example/hello_blocking.ml
+++ b/example/hello_blocking.ml
@@ -96,20 +96,28 @@ let%expect_test "hello commit" =
     with
     | Ok _ -> assert false
     | Error (`Vcs err) ->
-      (* Here we do not show the entire sexp because it is too unstable. Indeed,
-         it contains the whole context of the failure, including stderr, steps,
-         etc. For the purpose of the test here, we only verify that the error
-         message that the user provided is included. *)
-      let rec visit : Sexp.t -> bool = function
-        | List [ Atom "error"; Atom user_error ] ->
-          print_endline user_error;
-          true
-        | Atom _ -> false
-        | List sexps -> List.exists sexps ~f:visit
-      in
-      assert (visit (Vcs.Err.sexp_of_t err))
+      print_s
+        (Vcs_test_helpers.redact_sexp
+           (Vcs.Err.sexp_of_t err)
+           ~fields:[ "cwd"; "repo_root"; "stderr" ])
   in
-  [%expect {| Hello invalid exit code |}];
+  [%expect
+    {|
+    ((steps ((
+       Vcs.git (
+         (repo_root <REDACTED>)
+         (run_in_subdir ())
+         (env           ())
+         (args (rev-parse INVALID-REF))))))
+     (error (
+       (prog git)
+       (args        (rev-parse INVALID-REF))
+       (exit_status (Exited    128))
+       (cwd <REDACTED>)
+       (stdout (INVALID-REF))
+       (stderr <REDACTED>)
+       (error  "Hello invalid exit code"))))
+    |}];
   (* Here we only use [Eio] to clean up the temporary repo, because [rmtree] is
      a convenient function to use in this test. But the point is that the rest
      of the test used a blocking API. *)

--- a/lib/vcs_test_helpers/src/vcs_test_helpers.mli
+++ b/lib/vcs_test_helpers/src/vcs_test_helpers.mli
@@ -36,3 +36,44 @@ val init_temp_repo
   -> sw:Eio.Switch.t
   -> vcs:[> Vcs.Trait.config | Vcs.Trait.init ] Vcs.t
   -> Vcs.Repo_root.t
+
+(** This helper allows to filter out unstable and brittle parts of errors before
+    printing them in an expect test trace. The [fields] parameter specifies
+    which field-paths to redact.
+
+    In its most simple form, a [field] may simply be a field name that will end
+    up being redacted. For example, if the error is:
+
+    {[
+      ((field_a ...)
+       (field_b <UNSTABLE>))
+    ]}
+
+    then the [fields] parameter should be [["field_b"]], and in this case,
+    [redact_sexp error ~fields:["field_b"]] will result in:
+
+    {[
+      ((field_a ...)
+       (field_b <REDACTED>))
+    ]}
+
+    Some form of nesting is supported for convenience: in case you only want to
+    redact a field if it is nested deep into another field. In this case, the
+    syntax is to use a ["/"] separator in the field. For example, if the error
+    is:
+
+    {[
+      ((steps ((Vcs.init ((path /invalid/path)))))
+       (error (
+         (prog git)
+         (args (init .))
+         (exit_status Unknown)
+         (cwd         /invalid/path)
+         (stdout      "")
+         (stderr      "")
+         (error       <UNSTABLE>))))
+    ]}
+
+    then the [fields] parameter should be [["error/error"]]. You may mix nested
+    and non-nested fields in the same [fields] list. *)
+val redact_sexp : Sexp.t -> fields:string list -> Sexp.t

--- a/lib/vcs_test_helpers/test/test__vcs_test_helpers.ml
+++ b/lib/vcs_test_helpers/test/test__vcs_test_helpers.ml
@@ -100,5 +100,24 @@ let%expect_test "redact_sexp" =
        (stderr      <REDACTED>)
        (error       <REDACTED>))))
     |}];
+  (* Adding corner cases, such as empty nested fields. *)
+  let sexp =
+    Sexp.(
+      List
+        [ List [ Atom ""; Atom "empty" ]
+        ; List [ Atom ""; List [ Atom ""; Atom "empty" ] ]
+        ; List [ Atom "error"; Atom "error" ]
+        ])
+  in
+  print_s (Vcs_test_helpers.redact_sexp sexp ~fields:[]);
+  [%expect {| (("" empty) ("" ("" empty)) (error error)) |}];
+  print_s (Vcs_test_helpers.redact_sexp sexp ~fields:[ "" ]);
+  [%expect {|
+    ((""    <REDACTED>)
+     (""    <REDACTED>)
+     (error error))
+    |}];
+  print_s (Vcs_test_helpers.redact_sexp sexp ~fields:[ "/" ]);
+  [%expect {| (("" empty) ("" ("" <REDACTED>)) (error error)) |}];
   ()
 ;;

--- a/lib/vcs_test_helpers/test/test__vcs_test_helpers.ml
+++ b/lib/vcs_test_helpers/test/test__vcs_test_helpers.ml
@@ -60,3 +60,45 @@ let%expect_test "init_temp_repo" =
     --------------- |}];
   ()
 ;;
+
+let%expect_test "redact_sexp" =
+  Eio_main.run
+  @@ fun env ->
+  let vcs = Vcs_git.create ~env in
+  let invalid_path = Absolute_path.v "/invalid/path" in
+  let error =
+    match Vcs.init vcs ~path:invalid_path with
+    | _ -> assert false
+    | exception Vcs.E err -> [%sexp (err : Vcs.Err.t)]
+  in
+  print_s (Vcs_test_helpers.redact_sexp error ~fields:[ "error" ]);
+  [%expect {| ((steps ((Vcs.init ((path /invalid/path))))) (error <REDACTED>)) |}];
+  print_s (Vcs_test_helpers.redact_sexp error ~fields:[ "error/error" ]);
+  [%expect
+    {|
+    ((steps ((Vcs.init ((path /invalid/path)))))
+     (error (
+       (prog git)
+       (args (init .))
+       (exit_status Unknown)
+       (cwd         /invalid/path)
+       (stdout      "")
+       (stderr      "")
+       (error       <REDACTED>))))
+    |}];
+  print_s
+    (Vcs_test_helpers.redact_sexp error ~fields:[ "error/error"; "error/stderr"; "cwd" ]);
+  [%expect
+    {|
+    ((steps ((Vcs.init ((path /invalid/path)))))
+     (error (
+       (prog git)
+       (args (init .))
+       (exit_status Unknown)
+       (cwd         <REDACTED>)
+       (stdout      "")
+       (stderr      <REDACTED>)
+       (error       <REDACTED>))))
+    |}];
+  ()
+;;


### PR DESCRIPTION
Add a helper to replace brittle parts of errors in expect test by the stable constant string "\<REDACTED>". Use it to simplify some existing tests, and make other more robust to future error messages changes.