### PR TITLE
Unify process err context

### DIFF
--- a/example/hello_blocking.ml
+++ b/example/hello_blocking.ml
@@ -72,12 +72,7 @@ let%expect_test "hello commit" =
   in
   [%expect
     {|
-    ((steps ((
-       Vcs.git (
-         (repo_root /invalid/path)
-         (run_in_subdir ())
-         (env           ())
-         (args          ())))))
+    ((steps ((Vcs.git ((repo_root /invalid/path) (args ())))))
      (error (
        (prog git)
        (args ())
@@ -85,7 +80,8 @@ let%expect_test "hello commit" =
        (cwd         /invalid/path/)
        (stdout      "")
        (stderr      "")
-       (error ("Unix.Unix_error(Unix.ENOENT, \"chdir\", \"/invalid/path/\")"))))) |}];
+       (error ("Unix.Unix_error(Unix.ENOENT, \"chdir\", \"/invalid/path/\")")))))
+    |}];
   (* Let's also show a case where the command fails due to a user error. *)
   let () =
     match
@@ -103,12 +99,7 @@ let%expect_test "hello commit" =
   in
   [%expect
     {|
-    ((steps ((
-       Vcs.git (
-         (repo_root <REDACTED>)
-         (run_in_subdir ())
-         (env           ())
-         (args (rev-parse INVALID-REF))))))
+    ((steps ((Vcs.git ((repo_root <REDACTED>) (args (rev-parse INVALID-REF))))))
      (error (
        (prog git)
        (args        (rev-parse INVALID-REF))

--- a/example/hello_git_cli.ml
+++ b/example/hello_git_cli.ml
@@ -63,7 +63,7 @@ let%expect_test "hello cli" =
     Hello World!
     --------------- |}];
   (* Let's show also how to use the git cli in a case where we'd like to parse
-     its output, and how to do this with the non-parsing API of Vcs. *)
+     its output, and how to do this with the non-raising API of Vcs. *)
   let head_rev =
     Vcs.Or_error.git vcs ~repo_root ~args:[ "rev-parse"; "HEAD" ] ~f:(fun output ->
       let%bind stdout = Vcs.Git.exit0_and_stdout output in

--- a/example/hello_git_cli.ml
+++ b/example/hello_git_cli.ml
@@ -103,12 +103,7 @@ let%expect_test "hello cli" =
   in
   [%expect
     {|
-    ((steps ((
-       Vcs.git (
-         (repo_root <REDACTED>)
-         (run_in_subdir ())
-         (env           ())
-         (args (rev-parse INVALID-REF))))))
+    ((steps ((Vcs.git ((repo_root <REDACTED>) (args (rev-parse INVALID-REF))))))
      (error (
        (prog git)
        (args        (rev-parse INVALID-REF))

--- a/example/hello_git_cli.ml
+++ b/example/hello_git_cli.ml
@@ -86,7 +86,64 @@ let%expect_test "hello cli" =
   in
   print_string abbrev_head;
   [%expect {| main |}];
-  (* Let's also show a case where the command fails. *)
+  (* Cases where the command fails. *)
+  let () =
+    match
+      Vcs.git vcs ~repo_root ~args:[ "rev-parse"; "INVALID-REF" ] ~f:(fun output ->
+        if output.exit_code = 0
+        then assert false [@coverage off]
+        else failwith "Hello invalid exit code")
+    with
+    | _ -> assert false [@coverage off]
+    | exception exn ->
+      print_s
+        (Vcs_test_helpers.redact_sexp
+           [%sexp (exn : Exn.t)]
+           ~fields:[ "cwd"; "repo_root"; "stderr" ])
+  in
+  [%expect
+    {|
+    (lib/vcs/src/exn0.ml.E (
+      (steps ((Vcs.git ((repo_root <REDACTED>) (args (rev-parse INVALID-REF))))))
+      (error (
+        (prog git)
+        (args        (rev-parse INVALID-REF))
+        (exit_status (Exited    128))
+        (cwd    <REDACTED>)
+        (stdout INVALID-REF)
+        (stderr <REDACTED>)
+        (error (Failure "Hello invalid exit code"))))))
+    |}];
+  let () =
+    match
+      Vcs.Or_error.git
+        vcs
+        ~repo_root
+        ~args:[ "rev-parse"; "INVALID-REF" ]
+        ~f:(fun output ->
+          if output.exit_code = 0
+          then assert false [@coverage off]
+          else Or_error.error_string "Hello invalid exit code")
+    with
+    | Ok _ -> assert false
+    | Error error ->
+      print_s
+        (Vcs_test_helpers.redact_sexp
+           [%sexp (error : Error.t)]
+           ~fields:[ "cwd"; "repo_root"; "stderr" ])
+  in
+  [%expect
+    {|
+    ((steps ((Vcs.git ((repo_root <REDACTED>) (args (rev-parse INVALID-REF))))))
+     (error (
+       (prog git)
+       (args        (rev-parse INVALID-REF))
+       (exit_status (Exited    128))
+       (cwd    <REDACTED>)
+       (stdout INVALID-REF)
+       (stderr <REDACTED>)
+       (error  "Hello invalid exit code"))))
+    |}];
   let () =
     match
       Vcs.Result.git vcs ~repo_root ~args:[ "rev-parse"; "INVALID-REF" ] ~f:(fun output ->

--- a/lib/git_cli/src/log.ml
+++ b/lib/git_cli/src/log.ml
@@ -39,7 +39,8 @@ module Make (Runtime : Runtime.S) = struct
       ~cwd:(repo_root |> Vcs.Repo_root.to_absolute_path)
       ~args:[ "log"; "--all"; "--pretty=format:%H %P" ]
       ~f:(fun output ->
-        let%map output = Vcs.Git.exit0_and_stdout output in
-        List.map (String.split_lines output) ~f:(fun line -> parse_log_line_exn ~line))
+        let%bind output = Vcs.Git.exit0_and_stdout output in
+        Or_error.try_with (fun () ->
+          List.map (String.split_lines output) ~f:(fun line -> parse_log_line_exn ~line)))
   ;;
 end

--- a/lib/git_cli/src/refs.ml
+++ b/lib/git_cli/src/refs.ml
@@ -80,7 +80,7 @@ module Make (Runtime : Runtime.S) = struct
       ~cwd:(repo_root |> Vcs.Repo_root.to_absolute_path)
       ~args:[ "show-ref"; "--dereference" ]
       ~f:(fun output ->
-        let%map output = Vcs.Git.exit0_and_stdout output in
-        parse_lines_exn ~lines:(String.split_lines output))
+        let%bind output = Vcs.Git.exit0_and_stdout output in
+        Or_error.try_with (fun () -> parse_lines_exn ~lines:(String.split_lines output)))
   ;;
 end

--- a/lib/vcs/src/err.ml
+++ b/lib/vcs/src/err.ml
@@ -34,5 +34,6 @@ let to_error t =
   | _ :: _ -> Error.create_s (sexp_of_t t)
 ;;
 
+let of_error error = { steps = []; error }
 let add_context t ~step = { steps = Info.create_s step :: t.steps; error = t.error }
 let init error ~step = { steps = [ Info.create_s step ]; error }

--- a/lib/vcs/src/err.ml
+++ b/lib/vcs/src/err.ml
@@ -25,6 +25,10 @@ type t =
   }
 [@@deriving sexp_of]
 
+let sexp_of_t ({ steps; error } as t) =
+  if List.is_empty steps then Error.sexp_of_t error else sexp_of_t t
+;;
+
 let to_string_hum t = t |> sexp_of_t |> Sexp.to_string_hum
 let create_s sexp = { steps = []; error = Error.create_s sexp }
 

--- a/lib/vcs/src/err.mli
+++ b/lib/vcs/src/err.mli
@@ -42,8 +42,12 @@ val create_s : Sexp.t -> t
     inside the [Or_error] monad. *)
 val to_error : t -> Error.t
 
+(** Create an error with no initial step. *)
+val of_error : Error.t -> t
+
 (** Add a step of context into the stack trace contained by the error. *)
 val add_context : t -> step:Sexp.t -> t
 
-(** This is useful if you are starting from an [Error.t] initially. *)
+(** This is useful if you are starting from an [Error.t] initially with an
+    initial step. *)
 val init : Error.t -> step:Sexp.t -> t

--- a/lib/vcs/src/non_raising.ml
+++ b/lib/vcs/src/non_raising.ml
@@ -95,12 +95,6 @@ module Make (M : M) :
            (Err.init
               error
               ~step:
-                [%sexp
-                  "Vcs.git"
-                  , { repo_root : Repo_root.t
-                    ; run_in_subdir : Path_in_repo.t option
-                    ; env : string array option
-                    ; args : string list
-                    }]))
+                (Vcs0.Private.make_git_err_step ?env ?run_in_subdir ~repo_root ~args ())))
   ;;
 end

--- a/lib/vcs/src/vcs0.mli
+++ b/lib/vcs/src/vcs0.mli
@@ -36,4 +36,13 @@ module Private : sig
     -> args:string list
     -> f:(Git.Output.t -> 'a Or_error.t)
     -> 'a Or_error.t
+
+  (** Build the context for errors happening during [git]. *)
+  val make_git_err_step
+    :  ?env:string array
+    -> ?run_in_subdir:Path_in_repo.t
+    -> repo_root:Repo_root.t
+    -> args:string list
+    -> unit
+    -> Sexp.t
 end

--- a/lib/vcs/test/test__err.ml
+++ b/lib/vcs/test/test__err.ml
@@ -21,6 +21,51 @@
 
 let%expect_test "to_string_hum" =
   print_endline (Vcs.Err.to_string_hum (Vcs.Err.create_s [%sexp Hello]));
-  [%expect {| ((steps ()) (error Hello)) |}];
+  [%expect {| Hello |}];
+  ()
+;;
+
+let%expect_test "sexp_of_t" =
+  print_s [%sexp (Vcs.Err.create_s [%sexp Hello] : Vcs.Err.t)];
+  [%expect {| Hello |}];
+  print_s
+    [%sexp (Vcs.Err.init (Error.create_s [%sexp Hello]) ~step:[%sexp Step] : Vcs.Err.t)];
+  [%expect {| ((steps (Step)) (error Hello)) |}];
+  ()
+;;
+
+let%expect_test "to_error" =
+  let test err = print_s [%sexp (Vcs.Err.to_error err : Error.t)] in
+  test (Vcs.Err.create_s [%sexp Hello]);
+  [%expect {| Hello |}];
+  test (Vcs.Err.init (Error.create_s [%sexp Hello]) ~step:[%sexp Step]);
+  [%expect {| ((steps (Step)) (error Hello)) |}];
+  ()
+;;
+
+let%expect_test "of_error" =
+  let test err = print_s [%sexp (Vcs.Err.of_error err : Vcs.Err.t)] in
+  test (Error.create_s [%sexp Hello]);
+  [%expect {| Hello |}];
+  ()
+;;
+
+let%expect_test "add_context" =
+  let err = Vcs.Err.create_s [%sexp Hello] in
+  print_s [%sexp (err : Vcs.Err.t)];
+  [%expect {| Hello |}];
+  let err = Vcs.Err.add_context err ~step:[%sexp Step_1] in
+  print_s [%sexp (err : Vcs.Err.t)];
+  [%expect {| ((steps (Step_1)) (error Hello)) |}];
+  let err = Vcs.Err.add_context err ~step:[%sexp Step_2, { x = 42 }] in
+  print_s [%sexp (err : Vcs.Err.t)];
+  [%expect {| ((steps ((Step_2 ((x 42))) Step_1)) (error Hello)) |}];
+  ()
+;;
+
+let%expect_test "init" =
+  print_s
+    [%sexp (Vcs.Err.init (Error.create_s [%sexp Hello]) ~step:[%sexp Step] : Vcs.Err.t)];
+  [%expect {| ((steps (Step)) (error Hello)) |}];
   ()
 ;;

--- a/lib/vcs/test/test__result.ml
+++ b/lib/vcs/test/test__result.ml
@@ -21,7 +21,7 @@
 
 let%expect_test "pp_error" =
   Vcs.Result.pp_error Stdlib.Format.std_formatter (`Vcs (Vcs.Err.create_s [%sexp Hello]));
-  [%expect {| ((steps ()) (error Hello)) |}];
+  [%expect {| Hello |}];
   ()
 ;;
 
@@ -32,7 +32,7 @@ let%expect_test "error_to_msg" =
   test (Ok ());
   [%expect {| (Ok ()) |}];
   test (Error (`Vcs (Vcs.Err.create_s [%sexp Hello])));
-  [%expect {| (Error (Msg "((steps ()) (error Hello))")) |}];
+  [%expect {| (Error (Msg Hello)) |}];
   ()
 ;;
 
@@ -64,6 +64,6 @@ let%expect_test "open_error" =
     (Result.return () [@coverage off])
   in
   print_s [%sexp (result : (unit, [ `My_int_error of int | `Vcs of Vcs.Err.t ]) Result.t)];
-  [%expect {| (Error (Vcs ((steps ()) (error Vcs_error)))) |}];
+  [%expect {| (Error (Vcs Vcs_error)) |}];
   ()
 ;;

--- a/lib/vcs_command/src/vcs_command.ml
+++ b/lib/vcs_command/src/vcs_command.ml
@@ -91,7 +91,7 @@ let git_cmd =
      fun env ->
        let%bind { vcs; repo_root; context = _ } = Vcs_param.initialize ~env ~config in
        let%bind { Vcs.Git.Output.exit_code; stdout; stderr } =
-         Vcs.git vcs ~repo_root ~args ~f:return
+         Vcs.Or_error.git vcs ~repo_root ~args ~f:return
        in
        Eio_writer.print_string ~env stdout;
        Eio_writer.prerr_string ~env stderr;


### PR DESCRIPTION
- The error context built differs between `Vcs.git` and `Vcs.Or_error.git`. Unify them.
- Fix a typo
- Fix a potentially raising code, which is intended to return a `_ Or_error.t` instead.
- Add tests for `Vcs.Err`
- Add tests covering failure cases for `Vcs.git`
