### PR TITLE
Refactor `Vcs.Git` to clarify raising/non-raising APIs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,13 @@
 
 ### Added
 
-- Initiate a library `vcs-test-helpers` to help writing tests.
+- Add documentation website powered by Docusaurus. (#7, @mbarbin)
+- Initiate a library `vcs-test-helpers` to help writing tests. (#4, @mbarbin)
 - Add test showing how to do revision lookup from references using `Vcs.refs` and `Vcs.tree`.
 
 ### Changed
 
+- Refactor `Vcs.Git` to clarify raising/non-raising APIs (breaking change). (#9, @mbarbin)
 - Upgrade `ocaml` to `5.2`.
 - Upgrade `dune` to `3.16`.
 
@@ -20,7 +22,7 @@
 
 ### Removed
 
-- Removed `Vcs.rev_parse`, replaced by other dedicated function `Vcs.current_{branch,revision}`.
+- Removed `Vcs.rev_parse`, replaced by other dedicated function `Vcs.current_{branch,revision}`. (#3, @mbarbin)
 
 ## 0.0.1 (2024-03-19)
 

--- a/example/hello_git_cli.ml
+++ b/example/hello_git_cli.ml
@@ -95,24 +95,23 @@ let%expect_test "hello cli" =
         else failwith "Hello invalid exit code")
     with
     | _ -> assert false [@coverage off]
-    | exception exn ->
+    | exception Vcs.E err ->
       print_s
         (Vcs_test_helpers.redact_sexp
-           [%sexp (exn : Exn.t)]
+           [%sexp (err : Vcs.Err.t)]
            ~fields:[ "cwd"; "repo_root"; "stderr" ])
   in
   [%expect
     {|
-    (lib/vcs/src/exn0.ml.E (
-      (steps ((Vcs.git ((repo_root <REDACTED>) (args (rev-parse INVALID-REF))))))
-      (error (
-        (prog git)
-        (args        (rev-parse INVALID-REF))
-        (exit_status (Exited    128))
-        (cwd    <REDACTED>)
-        (stdout INVALID-REF)
-        (stderr <REDACTED>)
-        (error (Failure "Hello invalid exit code"))))))
+    ((steps ((Vcs.git ((repo_root <REDACTED>) (args (rev-parse INVALID-REF))))))
+     (error (
+       (prog git)
+       (args        (rev-parse INVALID-REF))
+       (exit_status (Exited    128))
+       (cwd    <REDACTED>)
+       (stdout INVALID-REF)
+       (stderr <REDACTED>)
+       (error (Failure "Hello invalid exit code")))))
     |}];
   let () =
     match

--- a/example/hello_git_cli.ml
+++ b/example/hello_git_cli.ml
@@ -66,7 +66,7 @@ let%expect_test "hello cli" =
      its output, and how to do this with the non-raising API of Vcs. *)
   let head_rev =
     Vcs.Or_error.git vcs ~repo_root ~args:[ "rev-parse"; "HEAD" ] ~f:(fun output ->
-      let%bind stdout = Vcs.Git.exit0_and_stdout output in
+      let%bind stdout = Vcs.Git.Or_error.exit0_and_stdout output in
       Vcs.Rev.of_string (String.strip stdout))
     |> Or_error.ok_exn
   in
@@ -177,7 +177,7 @@ let%expect_test "hello cli" =
       vcs
       ~repo_root
       ~args:[ "rev-parse"; "--abbrev-ref"; ref_ ]
-      ~f:Vcs.Git.exit0_and_stdout
+      ~f:Vcs.Git.Or_error.exit0_and_stdout
     >>| String.strip
   in
   (* You may be tempted to think the setup is ok, based on the happy path
@@ -215,7 +215,7 @@ let%expect_test "hello cli" =
       vcs
       ~repo_root
       ~args:[ "rev-parse"; "--abbrev-ref"; ref_ ]
-      ~f:Vcs.Git.exit0_and_stdout
+      ~f:Vcs.Git.Or_error.exit0_and_stdout
     >>| String.strip
   in
   (* The behavior is the same in the happy path. *)

--- a/example/hello_git_cli.ml
+++ b/example/hello_git_cli.ml
@@ -169,5 +169,191 @@ let%expect_test "hello cli" =
        (stderr <REDACTED>)
        (error  "Hello invalid exit code"))))
     |}];
+  (* Here we characterize some unintended ways the API may be abused. *)
+  (* 1. [Vcs.git] is meant to be used with a raising helper. In this section we
+     show undesirable effect of using it with a non-raising helper [f]. *)
+  let abbrev_ref ?(repo_root = repo_root) ref_ =
+    Vcs.git
+      vcs
+      ~repo_root
+      ~args:[ "rev-parse"; "--abbrev-ref"; ref_ ]
+      ~f:Vcs.Git.exit0_and_stdout
+    >>| String.strip
+  in
+  (* You may be tempted to think the setup is ok, based on the happy path
+     behavior. *)
+  print_s [%sexp (abbrev_ref "HEAD" : string Or_error.t)];
+  [%expect {| (Ok main) |}];
+  (* However, note that the call can still raise. *)
+  let () =
+    match abbrev_ref ~repo_root:(Vcs.Repo_root.v "/bogus") "HEAD" with
+    | _ -> assert false [@coverage off]
+    | exception Vcs.E err ->
+      print_s
+        (Vcs_test_helpers.redact_sexp [%sexp (err : Vcs.Err.t)] ~fields:[ "error/error" ])
+  in
+  [%expect
+    {|
+    ((steps ((Vcs.git ((repo_root /bogus) (args (rev-parse --abbrev-ref HEAD))))))
+     (error (
+       (prog git)
+       (args (rev-parse --abbrev-ref HEAD))
+       (exit_status Unknown)
+       (cwd         /bogus/)
+       (stdout      "")
+       (stderr      "")
+       (error       <REDACTED>))))
+    |}];
+  (* Another difference is that you do not get the context when the helper
+     returns an error. *)
+  print_s [%sexp (abbrev_ref "/bogus" : string Or_error.t)];
+  [%expect {| (Error "expected exit code 0") |}];
+  (* If you are using a non-raising handler [f], you probably mean to use
+     [Vcs.Or_error.git]. *)
+  let abbrev_ref ?(repo_root = repo_root) ref_ =
+    Vcs.Or_error.git
+      vcs
+      ~repo_root
+      ~args:[ "rev-parse"; "--abbrev-ref"; ref_ ]
+      ~f:Vcs.Git.exit0_and_stdout
+    >>| String.strip
+  in
+  (* The behavior is the same in the happy path. *)
+  print_s [%sexp (abbrev_ref "HEAD" : string Or_error.t)];
+  [%expect {| (Ok main) |}];
+  (* However, now the function will not raise. *)
+  print_s
+    (Vcs_test_helpers.redact_sexp
+       [%sexp
+         (abbrev_ref ~repo_root:(Vcs.Repo_root.v "/bogus") "HEAD" : string Or_error.t)]
+       ~fields:[ "error/error" ]);
+  [%expect
+    {|
+    (Error (
+      (steps ((Vcs.git ((repo_root /bogus) (args (rev-parse --abbrev-ref HEAD))))))
+      (error (
+        (prog git)
+        (args (rev-parse --abbrev-ref HEAD))
+        (exit_status Unknown)
+        (cwd         /bogus/)
+        (stdout      "")
+        (stderr      "")
+        (error       <REDACTED>)))))
+    |}];
+  (* And you do get the context when the helper returns an error. *)
+  let error_with_context =
+    match abbrev_ref "bogus" with
+    | Ok _ -> assert false [@coverage off]
+    | Error error -> Error.sexp_of_t error
+  in
+  print_s
+    (Vcs_test_helpers.redact_sexp
+       error_with_context
+       ~fields:[ "cwd"; "repo_root"; "stderr" ]);
+  [%expect
+    {|
+    ((steps ((
+       Vcs.git ((repo_root <REDACTED>) (args (rev-parse --abbrev-ref bogus))))))
+     (error (
+       (prog git)
+       (args (rev-parse --abbrev-ref bogus))
+       (exit_status (Exited 128))
+       (cwd    <REDACTED>)
+       (stdout bogus)
+       (stderr <REDACTED>)
+       (error  "expected exit code 0"))))
+    |}];
+  (* 2. Let's look now at [Vcs.Or_error.git]. It is meant to be used with a
+     non-raising handler [f]. Let's see what happens when [f] raises. *)
+  let abbrev_ref ?(repo_root = repo_root) ref_ =
+    Vcs.Or_error.git
+      vcs
+      ~repo_root
+      ~args:[ "rev-parse"; "--abbrev-ref"; ref_ ]
+      ~f:(fun { exit_code; stdout; stderr = _ } ->
+        match exit_code with
+        | 0 -> Or_error.return (String.strip stdout)
+        | _ -> failwith "Unexpected error code")
+  in
+  (* You may be tempted to think the setup is ok, based on the happy path
+     behavior. *)
+  print_s [%sexp (abbrev_ref "HEAD" : string Or_error.t)];
+  [%expect {| (Ok main) |}];
+  (* Some error condition will even correctly be turned into Errors, which may
+     further prevent you from hitting a raising case. *)
+  print_s
+    (Vcs_test_helpers.redact_sexp
+       [%sexp
+         (abbrev_ref ~repo_root:(Vcs.Repo_root.v "/bogus") "HEAD" : string Or_error.t)]
+       ~fields:[ "error/error" ]);
+  [%expect
+    {|
+    (Error (
+      (steps ((Vcs.git ((repo_root /bogus) (args (rev-parse --abbrev-ref HEAD))))))
+      (error (
+        (prog git)
+        (args (rev-parse --abbrev-ref HEAD))
+        (exit_status Unknown)
+        (cwd         /bogus/)
+        (stdout      "")
+        (stderr      "")
+        (error       <REDACTED>)))))
+    |}];
+  (* However when your handler raises, the function will raise too, and you
+     won't get the context in this case. *)
+  require_does_raise [%here] (fun () : string Or_error.t -> abbrev_ref "/bogus");
+  [%expect {| (Failure "Unexpected error code") |}];
+  (* If you use a raising handler [f], you probably mean to use [Vcs.git]. *)
+  let abbrev_ref ?(repo_root = repo_root) ref_ =
+    Vcs.git
+      vcs
+      ~repo_root
+      ~args:[ "rev-parse"; "--abbrev-ref"; ref_ ]
+      ~f:(fun { exit_code; stdout; stderr = _ } ->
+        match exit_code with
+        | 0 -> String.strip stdout
+        | _ -> failwith "Unexpected error code" [@coverage off])
+  in
+  (* You get a function that does not raise in the happy path. *)
+  print_s [%sexp (abbrev_ref "HEAD" : string)];
+  [%expect {| main |}];
+  (* And always raises [Vcs.E], with context, whether the error comes from your handler or not. *)
+  let abbrev_ref_does_raise ?repo_root ref_ ~redact_fields =
+    match abbrev_ref ?repo_root ref_ with
+    | _ -> assert false [@coverage off]
+    | exception Vcs.E err ->
+      print_s (Vcs_test_helpers.redact_sexp (Vcs.Err.sexp_of_t err) ~fields:redact_fields)
+  in
+  abbrev_ref_does_raise
+    ~repo_root:(Vcs.Repo_root.v "/bogus")
+    "HEAD"
+    ~redact_fields:[ "cwd"; "error/error"; "repo_root"; "stderr" ];
+  [%expect
+    {|
+    ((steps ((
+       Vcs.git ((repo_root <REDACTED>) (args (rev-parse --abbrev-ref HEAD))))))
+     (error (
+       (prog git)
+       (args (rev-parse --abbrev-ref HEAD))
+       (exit_status Unknown)
+       (cwd         <REDACTED>)
+       (stdout      "")
+       (stderr      <REDACTED>)
+       (error       <REDACTED>))))
+    |}];
+  abbrev_ref_does_raise "bogus" ~redact_fields:[ "cwd"; "repo_root"; "stderr" ];
+  [%expect
+    {|
+    ((steps ((
+       Vcs.git ((repo_root <REDACTED>) (args (rev-parse --abbrev-ref bogus))))))
+     (error (
+       (prog git)
+       (args (rev-parse --abbrev-ref bogus))
+       (exit_status (Exited 128))
+       (cwd    <REDACTED>)
+       (stdout bogus)
+       (stderr <REDACTED>)
+       (error (Failure "Unexpected error code")))))
+    |}];
   ()
 ;;

--- a/lib/git_cli/src/add.ml
+++ b/lib/git_cli/src/add.ml
@@ -27,6 +27,6 @@ module Make (Runtime : Runtime.S) = struct
       t
       ~cwd:(repo_root |> Vcs.Repo_root.to_absolute_path)
       ~args:[ "add"; path |> Vcs.Path_in_repo.to_string ]
-      ~f:Vcs.Git.exit0
+      ~f:Vcs.Git.Or_error.exit0
   ;;
 end

--- a/lib/git_cli/src/branch.ml
+++ b/lib/git_cli/src/branch.ml
@@ -27,6 +27,6 @@ module Make (Runtime : Runtime.S) = struct
       t
       ~cwd:(repo_root |> Vcs.Repo_root.to_absolute_path)
       ~args:[ "branch"; "--move"; to_ |> Vcs.Branch_name.to_string ]
-      ~f:Vcs.Git.exit0
+      ~f:Vcs.Git.Or_error.exit0
   ;;
 end

--- a/lib/git_cli/src/commit.ml
+++ b/lib/git_cli/src/commit.ml
@@ -27,6 +27,6 @@ module Make (Runtime : Runtime.S) = struct
       t
       ~cwd:(repo_root |> Vcs.Repo_root.to_absolute_path)
       ~args:[ "commit"; "-m"; commit_message |> Vcs.Commit_message.to_string ]
-      ~f:Vcs.Git.exit0
+      ~f:Vcs.Git.Or_error.exit0
   ;;
 end

--- a/lib/git_cli/src/config.ml
+++ b/lib/git_cli/src/config.ml
@@ -27,7 +27,7 @@ module Make (Runtime : Runtime.S) = struct
       t
       ~cwd:(repo_root |> Vcs.Repo_root.to_absolute_path)
       ~args:[ "config"; "user.name"; user_name |> Vcs.User_name.to_string ]
-      ~f:Vcs.Git.exit0
+      ~f:Vcs.Git.Or_error.exit0
   ;;
 
   let set_user_email t ~repo_root ~user_email =
@@ -35,6 +35,6 @@ module Make (Runtime : Runtime.S) = struct
       t
       ~cwd:(repo_root |> Vcs.Repo_root.to_absolute_path)
       ~args:[ "config"; "user.email"; user_email |> Vcs.User_email.to_string ]
-      ~f:Vcs.Git.exit0
+      ~f:Vcs.Git.Or_error.exit0
   ;;
 end

--- a/lib/git_cli/src/init.ml
+++ b/lib/git_cli/src/init.ml
@@ -23,7 +23,9 @@ module Make (Runtime : Runtime.S) = struct
   type t = Runtime.t
 
   let init t ~path =
-    let%bind () = Runtime.git t ~cwd:path ~args:[ "init"; "." ] ~f:Vcs.Git.exit0 in
+    let%bind () =
+      Runtime.git t ~cwd:path ~args:[ "init"; "." ] ~f:Vcs.Git.Or_error.exit0
+    in
     return (path |> Vcs.Repo_root.of_absolute_path)
   ;;
 end

--- a/lib/git_cli/src/log.ml
+++ b/lib/git_cli/src/log.ml
@@ -39,7 +39,7 @@ module Make (Runtime : Runtime.S) = struct
       ~cwd:(repo_root |> Vcs.Repo_root.to_absolute_path)
       ~args:[ "log"; "--all"; "--pretty=format:%H %P" ]
       ~f:(fun output ->
-        let%bind output = Vcs.Git.exit0_and_stdout output in
+        let%bind output = Vcs.Git.Or_error.exit0_and_stdout output in
         Or_error.try_with (fun () ->
           List.map (String.split_lines output) ~f:(fun line -> parse_log_line_exn ~line)))
   ;;

--- a/lib/git_cli/src/ls_files.ml
+++ b/lib/git_cli/src/ls_files.ml
@@ -28,7 +28,7 @@ module Make (Runtime : Runtime.S) = struct
       ~cwd:(Vcs.Repo_root.append repo_root below)
       ~args:[ "ls-files"; "--full-name" ]
       ~f:(fun output ->
-        let%bind stdout = Vcs.Git.exit0_and_stdout output in
+        let%bind stdout = Vcs.Git.Or_error.exit0_and_stdout output in
         Or_error.try_with (fun () ->
           String.split_lines stdout
           |> List.map ~f:(fun path ->

--- a/lib/git_cli/src/name_status.ml
+++ b/lib/git_cli/src/name_status.ml
@@ -104,7 +104,7 @@ module Make (Runtime : Runtime.S) = struct
       ~cwd:(repo_root |> Vcs.Repo_root.to_absolute_path)
       ~args:[ "diff"; "--name-status"; changed_param ]
       ~f:(fun output ->
-        let%bind stdout = Vcs.Git.exit0_and_stdout output in
+        let%bind stdout = Vcs.Git.Or_error.exit0_and_stdout output in
         Or_error.try_with (fun () -> parse_lines_exn ~lines:(String.split_lines stdout)))
   ;;
 end

--- a/lib/git_cli/src/num_status.ml
+++ b/lib/git_cli/src/num_status.ml
@@ -74,7 +74,7 @@ module Make (Runtime : Runtime.S) = struct
       ~cwd:(repo_root |> Vcs.Repo_root.to_absolute_path)
       ~args:[ "diff"; "--numstat"; changed_param ]
       ~f:(fun output ->
-        let%bind stdout = Vcs.Git.exit0_and_stdout output in
+        let%bind stdout = Vcs.Git.Or_error.exit0_and_stdout output in
         Or_error.try_with (fun () -> parse_lines_exn ~lines:(String.split_lines stdout)))
   ;;
 end

--- a/lib/git_cli/src/refs.ml
+++ b/lib/git_cli/src/refs.ml
@@ -80,7 +80,7 @@ module Make (Runtime : Runtime.S) = struct
       ~cwd:(repo_root |> Vcs.Repo_root.to_absolute_path)
       ~args:[ "show-ref"; "--dereference" ]
       ~f:(fun output ->
-        let%bind output = Vcs.Git.exit0_and_stdout output in
+        let%bind output = Vcs.Git.Or_error.exit0_and_stdout output in
         Or_error.try_with (fun () -> parse_lines_exn ~lines:(String.split_lines output)))
   ;;
 end

--- a/lib/git_cli/src/rev_parse.ml
+++ b/lib/git_cli/src/rev_parse.ml
@@ -28,7 +28,7 @@ module Make (Runtime : Runtime.S) = struct
       ~cwd:(repo_root |> Vcs.Repo_root.to_absolute_path)
       ~args:[ "rev-parse"; "--abbrev-ref"; "HEAD" ]
       ~f:(fun output ->
-        let%bind stdout = Vcs.Git.exit0_and_stdout output in
+        let%bind stdout = Vcs.Git.Or_error.exit0_and_stdout output in
         Vcs.Branch_name.of_string (String.strip stdout))
   ;;
 
@@ -38,7 +38,7 @@ module Make (Runtime : Runtime.S) = struct
       ~cwd:(repo_root |> Vcs.Repo_root.to_absolute_path)
       ~args:[ "rev-parse"; "--verify"; "HEAD^{commit}" ]
       ~f:(fun output ->
-        let%bind stdout = Vcs.Git.exit0_and_stdout output in
+        let%bind stdout = Vcs.Git.Or_error.exit0_and_stdout output in
         Vcs.Rev.of_string (String.strip stdout))
   ;;
 end

--- a/lib/git_cli/test/test__show.ml
+++ b/lib/git_cli/test/test__show.ml
@@ -31,6 +31,6 @@ let%expect_test "show" =
   test { exit_code = 128; stdout = "contents"; stderr = "" };
   [%expect {| (Ok Absent) |}];
   test { exit_code = 1; stdout = "contents"; stderr = "" };
-  [%expect {| (Error "expected error code 0 or 128") |}];
+  [%expect {| (Error ("unexpected exit code" ((accepted_codes (0 128))))) |}];
   ()
 ;;

--- a/lib/vcs/src/git.mli
+++ b/lib/vcs/src/git.mli
@@ -19,10 +19,11 @@
 (*_  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*_******************************************************************************)
 
-(** Manipulating the output of process running the ["git"] command. *)
+(** Manipulating the output of process run by vcs and providers - typically the
+    ["git"] command. *)
 
 module Output : sig
-  type t =
+  type t = Git_output0.t =
     { exit_code : int
     ; stdout : string
     ; stderr : string
@@ -30,7 +31,33 @@ module Output : sig
   [@@deriving sexp_of]
 end
 
-(** {1 Output wrappers} *)
+(** This is the interface commonly used by raising and non-raising helper
+    modules, such as {!module:Vcs.Git}, {!module:Vcs.Git.Or_error},
+    {!module:Vcs.Git.Result}, and custom ones built with
+    {!module:Vcs.Git.Non_raising.Make}. [S] is parametrized by the result
+    type returned by the helpers. *)
+module type S = Vcs_interface.Process_S
 
-val exit0 : Output.t -> unit Or_error.t
-val exit0_and_stdout : Output.t -> string Or_error.t
+(** The interface exposed at the top level of this module are helpers that
+    return direct results, or raise {!exception:Vcs.E}. This module is
+    exported to users as [Vcs.Git].
+
+    The helpers are suitable for use in combination with the {!val:Vcs.git}
+    function, which will take care of wrapping the exception with useful
+    context, before re-raising it. *)
+include S with type 'a result := 'a
+
+module Non_raising : sig
+  (** A functor to build non raising helpers based on a custom result type.
+
+      In addition to {!module:Vcs.Git.Or_error} and {!module:Vcs.Git.Result}, we
+      provide this functor to create a [Git.S] interface based on a custom
+      result type of your choice. *)
+
+  module type M = Vcs_interface.Error_S
+
+  module Make (M : M) : S with type 'a result := ('a, M.err) Result.t
+end
+
+module Or_error : S with type 'a result := ('a, Vcs_or_error0.err) Result.t
+module Result : S with type 'a result := ('a, Vcs_result0.err) Result.t

--- a/lib/vcs/src/git_output0.ml
+++ b/lib/vcs/src/git_output0.ml
@@ -19,26 +19,15 @@
 (*  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*******************************************************************************)
 
-let interpret_output output =
-  match%map Vcs.Git.Or_error.exit_code output ~accept:[ 0, `Present; 128, `Absent ] with
-  | `Present -> `Present (Vcs.File_contents.create output.stdout)
-  | `Absent -> `Absent
-;;
+module T = struct
+  [@@@coverage off]
 
-module Make (Runtime : Runtime.S) = struct
-  type t = Runtime.t
-
-  let show_file_at_rev t ~repo_root ~rev ~path =
-    Runtime.git
-      t
-      ~cwd:(repo_root |> Vcs.Repo_root.to_absolute_path)
-      ~args:
-        [ "show"
-        ; Printf.sprintf
-            "%s:%s"
-            (rev |> Vcs.Rev.to_string)
-            (path |> Vcs.Path_in_repo.to_string)
-        ]
-      ~f:interpret_output
-  ;;
+  type t =
+    { exit_code : int
+    ; stdout : string
+    ; stderr : string
+    }
+  [@@deriving sexp_of]
 end
+
+include T

--- a/lib/vcs/src/git_output0.mli
+++ b/lib/vcs/src/git_output0.mli
@@ -19,14 +19,14 @@
 (*_  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*_******************************************************************************)
 
-module type S = sig
-  type t
+(** Manipulating the output of process run by vcs and providers.
 
-  val git
-    :  ?env:string Export.array
-    -> t
-    -> cwd:Absolute_path.t
-    -> args:string list
-    -> f:(Git_output0.t -> 'a Or_error.t)
-    -> 'a Or_error.t
-end
+    This module is used to break a dependency cycle. It is exported as
+    [Vcs.Git.Output]. *)
+
+type t =
+  { exit_code : int
+  ; stdout : string
+  ; stderr : string
+  }
+[@@deriving sexp_of]

--- a/lib/vcs/src/non_raising.mli
+++ b/lib/vcs/src/non_raising.mli
@@ -22,8 +22,9 @@
 (** A functor to build non raising interfaces for [Vcs] based on a custom result
     type.
 
-    In addition to [Or_error] and [Result], we provide this functor to create a
-    [Vcs] interface based on a custom result type of your choice. *)
+    In addition to {!module:Vcs.Or_error} and {!module:Vcs.Result}, we provide
+    this functor to create a [Vcs] interface based on a custom result type of
+    your choice. See also {!module:Vcs.Git.Non_raising.Make}. *)
 
 module type M = Vcs_interface.Error_S
 module type S = Vcs_interface.S

--- a/lib/vcs/src/vcs.mli
+++ b/lib/vcs/src/vcs.mli
@@ -232,11 +232,39 @@ module Git = Git
 
 (** Note a non trivial behavior nuance depending on whether you are using this
     function using the raising or non-raising API. In the raising API, [f] is
-    allowed to raise, and [git] will catch any exception raised by [f], and
-    rewrap it under a proper [E err] exception with added context. In the
-    non-raising APIs, if [f] raises instead of returning an [Error], that
-    exception would escape the function [git] and be raised by [git] as an
-    uncaught exception. This would be considered a programming error. *)
+    allowed to raise: [git] will catch any exception raised by [f], and rewrap
+    it under a proper [E err] exception with added context. In the non-raising
+    APIs, if [f] raises instead of returning an [Error], that exception would
+    escape the function [git] and be raised by [git] as an uncaught exception.
+    This would be considered a programming error.
+
+    Some helpers are provided by the module {!module:Git} to help you build the
+    [f] parameter. Non-raising modules are also included in the [Git] module
+    dedicated to their respective result type (see for example
+    {!module:Vcs.Git.Or_error}).
+
+    The expectation is that you should be using the [Git] module of the API you
+    are using to access the [git] function, and not mix and match.
+
+    For example:
+
+    {[
+      let git_status () : string =
+        Vcs.git vcs ~repo_root ~args:[ "status" ] ~f:Vcs.Git.exit0_and_stdout
+      ;;
+    ]}
+
+    Or:
+
+    {[
+      let git_status () : string Or_error.t =
+        Vcs.Or_error.git
+          vcs
+          ~repo_root
+          ~args:[ "status" ]
+          ~f:Vcs.Git.Or_error.exit0_and_stdout
+      ;;
+    ]} *)
 val git
   :  ?env:string array
   -> ?run_in_subdir:Path_in_repo.t

--- a/lib/vcs/src/vcs_interface.mli
+++ b/lib/vcs/src/vcs_interface.mli
@@ -24,6 +24,24 @@
     This file is configured in [dune] as an interface only file, so we don't need to
     duplicate the interfaces it contains into an [ml] file. *)
 
+module type Process_S0 = sig
+  (** Helpers to wrap process outputs. *)
+
+  type process_output
+  type 'a result
+
+  val exit0 : process_output -> unit result
+  val exit0_and_stdout : process_output -> string result
+
+  (** A convenient wrapper to write exhaustive match on a result conditioned by
+      a list of accepted exit codes. If the exit code is not part of the
+      accepted list, the function takes care of returning an error of the
+      expected result type. *)
+  val exit_code : process_output -> accept:(int * 'a) list -> 'a result
+end
+
+module type Process_S = Process_S0 with type process_output := Git_output0.t
+
 module type S = sig
   (** The interface exported by [Vcs].
 
@@ -116,14 +134,19 @@ module type S = sig
     -> user_email:User_email.t
     -> unit result
 
-  (** See the note in {!val:Vcs.git} about error handling with respect to exceptions raised by [f]. *)
+  (** See the note in {!val:Vcs.git} about error handling with respect to
+      exceptions raised by [f].
+
+      Some helpers dedicated to the corresponding result type are provided by
+      the module {!module:Vcs.Git}. They are convenient to use to build the [f]
+      parameter. *)
   val git
     :  ?env:string array
     -> ?run_in_subdir:Path_in_repo.t
     -> [> Trait.git ] t
     -> repo_root:Repo_root.t
     -> args:string list
-    -> f:(Git.Output.t -> 'a result)
+    -> f:(Git_output0.t -> 'a result)
     -> 'a result
 end
 

--- a/lib/vcs/src/vcs_or_error.ml
+++ b/lib/vcs/src/vcs_or_error.ml
@@ -19,12 +19,7 @@
 (*  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*******************************************************************************)
 
-type err = Error.t
+type err = Vcs_or_error0.err
 type 'a result = ('a, err) Result.t
 
-include Non_raising.Make (struct
-    type nonrec err = err
-
-    let map_error = Err.to_error
-    let to_error = Fn.id
-  end)
+include Non_raising.Make (Vcs_or_error0)

--- a/lib/vcs/src/vcs_or_error0.ml
+++ b/lib/vcs/src/vcs_or_error0.ml
@@ -19,26 +19,7 @@
 (*  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*******************************************************************************)
 
-let interpret_output output =
-  match%map Vcs.Git.Or_error.exit_code output ~accept:[ 0, `Present; 128, `Absent ] with
-  | `Present -> `Present (Vcs.File_contents.create output.stdout)
-  | `Absent -> `Absent
-;;
+type err = Error.t
 
-module Make (Runtime : Runtime.S) = struct
-  type t = Runtime.t
-
-  let show_file_at_rev t ~repo_root ~rev ~path =
-    Runtime.git
-      t
-      ~cwd:(repo_root |> Vcs.Repo_root.to_absolute_path)
-      ~args:
-        [ "show"
-        ; Printf.sprintf
-            "%s:%s"
-            (rev |> Vcs.Rev.to_string)
-            (path |> Vcs.Path_in_repo.to_string)
-        ]
-      ~f:interpret_output
-  ;;
-end
+let map_error = Err.to_error
+let to_error = Fn.id

--- a/lib/vcs/src/vcs_or_error0.mli
+++ b/lib/vcs/src/vcs_or_error0.mli
@@ -19,14 +19,4 @@
 (*_  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*_******************************************************************************)
 
-module type S = sig
-  type t
-
-  val git
-    :  ?env:string Export.array
-    -> t
-    -> cwd:Absolute_path.t
-    -> args:string list
-    -> f:(Git_output0.t -> 'a Or_error.t)
-    -> 'a Or_error.t
-end
+include Vcs_interface.Error_S with type err = Error.t

--- a/lib/vcs/src/vcs_result.ml
+++ b/lib/vcs/src/vcs_result.ml
@@ -19,15 +19,10 @@
 (*  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*******************************************************************************)
 
-type err = [ `Vcs of Err.t ]
+type err = Vcs_result0.err
 type 'a result = ('a, err) Result.t
 
-include Non_raising.Make (struct
-    type nonrec err = err
-
-    let map_error err = `Vcs err
-    let to_error (`Vcs err) = Err.to_error err
-  end)
+include Non_raising.Make (Vcs_result0)
 
 let pp_error fmt (`Vcs err) = Stdlib.Format.pp_print_string fmt (Err.to_string_hum err)
 

--- a/lib/vcs/src/vcs_result0.ml
+++ b/lib/vcs/src/vcs_result0.ml
@@ -19,26 +19,7 @@
 (*  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*******************************************************************************)
 
-let interpret_output output =
-  match%map Vcs.Git.Or_error.exit_code output ~accept:[ 0, `Present; 128, `Absent ] with
-  | `Present -> `Present (Vcs.File_contents.create output.stdout)
-  | `Absent -> `Absent
-;;
+type err = [ `Vcs of Err.t ]
 
-module Make (Runtime : Runtime.S) = struct
-  type t = Runtime.t
-
-  let show_file_at_rev t ~repo_root ~rev ~path =
-    Runtime.git
-      t
-      ~cwd:(repo_root |> Vcs.Repo_root.to_absolute_path)
-      ~args:
-        [ "show"
-        ; Printf.sprintf
-            "%s:%s"
-            (rev |> Vcs.Rev.to_string)
-            (path |> Vcs.Path_in_repo.to_string)
-        ]
-      ~f:interpret_output
-  ;;
-end
+let map_error err = `Vcs err
+let to_error (`Vcs err) = Err.to_error err

--- a/lib/vcs/src/vcs_result0.mli
+++ b/lib/vcs/src/vcs_result0.mli
@@ -19,14 +19,4 @@
 (*_  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*_******************************************************************************)
 
-module type S = sig
-  type t
-
-  val git
-    :  ?env:string Export.array
-    -> t
-    -> cwd:Absolute_path.t
-    -> args:string list
-    -> f:(Git_output0.t -> 'a Or_error.t)
-    -> 'a Or_error.t
-end
+include Vcs_interface.Error_S with type err = [ `Vcs of Err.t ]

--- a/lib/vcs/test/test__git.ml
+++ b/lib/vcs/test/test__git.ml
@@ -20,7 +20,7 @@
 (*******************************************************************************)
 
 let%expect_test "exit0" =
-  let test output = print_s [%sexp (Vcs.Git.exit0 output : unit Or_error.t)] in
+  let test output = print_s [%sexp (Vcs.Git.Or_error.exit0 output : unit Or_error.t)] in
   test { exit_code = 0; stdout = ""; stderr = "" };
   [%expect {| (Ok ()) |}];
   (* The error does not contain the stdout or stderr, as this is already handled
@@ -33,12 +33,29 @@ let%expect_test "exit0" =
 
 let%expect_test "exit0_and_stdout" =
   let test output =
-    print_s [%sexp (Vcs.Git.exit0_and_stdout output : string Or_error.t)]
+    print_s [%sexp (Vcs.Git.Or_error.exit0_and_stdout output : string Or_error.t)]
   in
   test { exit_code = 0; stdout = "stdout"; stderr = "" };
   [%expect {| (Ok stdout) |}];
   (* Same remark as in [exit0] regarding the error trace. *)
   test { exit_code = 1; stdout = "stdout"; stderr = "stderr" };
   [%expect {| (Error "expected exit code 0") |}];
+  ()
+;;
+
+let%expect_test "exit_code" =
+  let test output =
+    print_s
+      [%sexp
+        (Vcs.Git.Or_error.exit_code output ~accept:[ 0, "ok"; 42, "other" ]
+         : string Or_error.t)]
+  in
+  test { exit_code = 0; stdout = ""; stderr = "" };
+  [%expect {| (Ok ok) |}];
+  test { exit_code = 42; stdout = ""; stderr = "" };
+  [%expect {| (Ok other) |}];
+  (* Same remark as in [exit0] regarding the error trace. *)
+  test { exit_code = 1; stdout = ""; stderr = "" };
+  [%expect {| (Error ("unexpected exit code" ((accepted_codes (0 42))))) |}];
   ()
 ;;

--- a/lib/vcs/test/test__git.ml
+++ b/lib/vcs/test/test__git.ml
@@ -19,13 +19,63 @@
 (*  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*******************************************************************************)
 
+(* [Vcs.Git] *)
+
+let%expect_test "exit0" =
+  let test output =
+    match Vcs.Git.exit0 output with
+    | () -> print_s [%sexp Ok ()]
+    | exception Vcs.E err -> print_s [%sexp Raised (err : Vcs.Err.t)]
+  in
+  test { exit_code = 0; stdout = ""; stderr = "" };
+  [%expect {| (Ok ()) |}];
+  (* The error does not contain the stdout or stderr, as this is already handled
+     by the code that interprets the result of the user function supplied to
+     [Vcs.git]. *)
+  test { exit_code = 1; stdout = "stdout"; stderr = "stderr" };
+  [%expect {| (Raised "expected exit code 0") |}];
+  ()
+;;
+
+let%expect_test "exit0_and_stdout" =
+  let test output =
+    match Vcs.Git.exit0_and_stdout output with
+    | stdout -> print_s [%sexp (stdout : string)]
+    | exception Vcs.E err -> print_s [%sexp Raised (err : Vcs.Err.t)]
+  in
+  test { exit_code = 0; stdout = "stdout"; stderr = "" };
+  [%expect {| stdout |}];
+  (* Same remark as in [exit0] regarding the error trace. *)
+  test { exit_code = 1; stdout = "stdout"; stderr = "stderr" };
+  [%expect {| (Raised "expected exit code 0") |}];
+  ()
+;;
+
+let%expect_test "exit_code" =
+  let test output =
+    match Vcs.Git.exit_code output ~accept:[ 0, "ok"; 42, "other" ] with
+    | result -> print_s [%sexp Ok (result : string)]
+    | exception Vcs.E err -> print_s [%sexp Raised (err : Vcs.Err.t)]
+  in
+  test { exit_code = 0; stdout = ""; stderr = "" };
+  [%expect {| (Ok ok) |}];
+  test { exit_code = 42; stdout = ""; stderr = "" };
+  [%expect {| (Ok other) |}];
+  (* Same remark as in [exit0] regarding the error trace. *)
+  test { exit_code = 1; stdout = ""; stderr = "" };
+  [%expect {| (Raised ("unexpected exit code" ((accepted_codes (0 42))))) |}];
+  ()
+;;
+
+(* [Vcs.Git.Or_error] *)
+
 let%expect_test "exit0" =
   let test output = print_s [%sexp (Vcs.Git.Or_error.exit0 output : unit Or_error.t)] in
   test { exit_code = 0; stdout = ""; stderr = "" };
   [%expect {| (Ok ()) |}];
   (* The error does not contain the stdout or stderr, as this is already handled
      by the code that interprets the result of the user function supplied to
-     [Vcs.git]. *)
+     [Vcs.Or_error.git]. *)
   test { exit_code = 1; stdout = "stdout"; stderr = "stderr" };
   [%expect {| (Error "expected exit code 0") |}];
   ()
@@ -49,6 +99,54 @@ let%expect_test "exit_code" =
       [%sexp
         (Vcs.Git.Or_error.exit_code output ~accept:[ 0, "ok"; 42, "other" ]
          : string Or_error.t)]
+  in
+  test { exit_code = 0; stdout = ""; stderr = "" };
+  [%expect {| (Ok ok) |}];
+  test { exit_code = 42; stdout = ""; stderr = "" };
+  [%expect {| (Ok other) |}];
+  (* Same remark as in [exit0] regarding the error trace. *)
+  test { exit_code = 1; stdout = ""; stderr = "" };
+  [%expect {| (Error ("unexpected exit code" ((accepted_codes (0 42))))) |}];
+  ()
+;;
+
+(* [Vcs.Git.Result] *)
+
+let%expect_test "exit0" =
+  let test output =
+    match Vcs.Git.Result.exit0 output with
+    | Ok () -> print_s [%sexp Ok]
+    | Error (`Vcs err) -> print_s [%sexp Error (err : Vcs.Err.t)]
+  in
+  test { exit_code = 0; stdout = ""; stderr = "" };
+  [%expect {| Ok |}];
+  (* The error does not contain the stdout or stderr, as this is already handled
+     by the code that interprets the result of the user function supplied to
+     [Vcs.Result.git]. *)
+  test { exit_code = 1; stdout = "stdout"; stderr = "stderr" };
+  [%expect {| (Error "expected exit code 0") |}];
+  ()
+;;
+
+let%expect_test "exit0_and_stdout" =
+  let test output =
+    match Vcs.Git.Result.exit0_and_stdout output with
+    | Ok stdout -> print_s [%sexp Ok (stdout : string)]
+    | Error (`Vcs err) -> print_s [%sexp Error (err : Vcs.Err.t)]
+  in
+  test { exit_code = 0; stdout = "stdout"; stderr = "" };
+  [%expect {| (Ok stdout) |}];
+  (* Same remark as in [exit0] regarding the error trace. *)
+  test { exit_code = 1; stdout = "stdout"; stderr = "stderr" };
+  [%expect {| (Error "expected exit code 0") |}];
+  ()
+;;
+
+let%expect_test "exit_code" =
+  let test output =
+    match Vcs.Git.Result.exit_code output ~accept:[ 0, "ok"; 42, "other" ] with
+    | Ok result -> print_s [%sexp Ok (result : string)]
+    | Error (`Vcs err) -> print_s [%sexp Error (err : Vcs.Err.t)]
   in
   test { exit_code = 0; stdout = ""; stderr = "" };
   [%expect {| (Ok ok) |}];

--- a/test/expect/find_ref.ml
+++ b/test/expect/find_ref.ml
@@ -67,12 +67,10 @@ let%expect_test "find ref" =
   (* We'll now create 2 diverging branches. *)
   let create_branch branch_name =
     Vcs.git vcs ~repo_root ~args:[ "branch"; branch_name ] ~f:Vcs.Git.exit0
-    |> Or_error.ok_exn
   in
   List.iter [ "branch1"; "branch2" ] ~f:create_branch;
   let commit_change branch =
-    Vcs.git vcs ~repo_root ~args:[ "checkout"; branch ] ~f:Vcs.Git.exit0
-    |> Or_error.ok_exn;
+    Vcs.git vcs ~repo_root ~args:[ "checkout"; branch ] ~f:Vcs.Git.exit0;
     commit_file
       vcs
       ~repo_root
@@ -98,7 +96,6 @@ let%expect_test "find ref" =
      on references provided by the user. *)
   let create_tag tag rev =
     Vcs.git vcs ~repo_root ~args:[ "tag"; tag; Vcs.Rev.to_string rev ] ~f:Vcs.Git.exit0
-    |> Or_error.ok_exn
   in
   create_tag "tag1" branch1_head;
   (* Tag "branch1" points to [branch2_head]. This isn't a typo, we purposely
@@ -164,9 +161,9 @@ let%expect_test "find ref" =
       vcs
       ~repo_root
       ~args:[ "rev-parse"; "--verify"; "branch1^{commit}" ]
-      ~f:(fun ({ stdout = _; stderr; exit_code = _ } as output) ->
+      ~f:(fun ({ exit_code = _; stdout = _; stderr } as output) ->
         print_endline stderr;
-        Vcs.Git.exit0_and_stdout output |> Or_error.ok_exn)
+        Vcs.Git.exit0_and_stdout output)
     |> String.strip
     |> Vcs.Rev.v
   in

--- a/test/expect/find_ref.ml
+++ b/test/expect/find_ref.ml
@@ -164,10 +164,9 @@ let%expect_test "find ref" =
       vcs
       ~repo_root
       ~args:[ "rev-parse"; "--verify"; "branch1^{commit}" ]
-      ~f:(fun ({ Vcs.Git.Output.stdout = _; stderr; exit_code = _ } as output) ->
+      ~f:(fun ({ stdout = _; stderr; exit_code = _ } as output) ->
         print_endline stderr;
-        Vcs.Git.exit0_and_stdout output)
-    |> Or_error.ok_exn
+        Vcs.Git.exit0_and_stdout output |> Or_error.ok_exn)
     |> String.strip
     |> Vcs.Rev.v
   in


### PR DESCRIPTION
Better distinguish distinction between raising and non-raising API for `Vcs.Git`. Improve documentation and add examples characterizing invalid usage.

This was prompted by noticing in using code some invalid mix of both APIs, and I decided to clean it up a bit.

I also added a new helper to help matching git outputs when multiple exit codes are accepted.

This change breaks the compatibility with the former API of `Vcs.Git` since the helpers exposes now raise instead of returning an `_ Or_error.t`. Migration path is to simply switch from `Vcs.Git` to `Vcs.Git.Or_error`, for example:

```diff
-| Vcs.Git.exit0
+| Vcs.Git.Or_error.exit0
```