### PR TITLE
Refactor node

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 
 ### Changed
 
+- Improve `Vcs.Tree.Node` interface.
 - Improve `Vcs.Tree.sexp_of_t` to help with debugging.
 - Rename `git_cli` library to `vcs_git_cli` for consistency.
 - Remove type parameter for `Vcs.Tree.Node_kind` (simplify interface).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 
 ### Changed
 
+- Rename `Vcs.Descendance.t` constructors for clarity.
 - Improve `Vcs.Tree.Node` interface.
 - Improve `Vcs.Tree.sexp_of_t` to help with debugging.
 - Rename `git_cli` library to `vcs_git_cli` for consistency.

--- a/lib/vcs/src/tree.ml
+++ b/lib/vcs/src/tree.ml
@@ -320,21 +320,21 @@ module Descendance = struct
   [@@@coverage off]
 
   type t =
-    | Same
+    | Same_node
     | Strict_ancestor
     | Strict_descendant
-    | Unrelated
+    | Other
   [@@deriving equal, enumerate, hash, sexp_of]
 end
 
 let descendance t a b : Descendance.t =
   if a = b
-  then Same
+  then Same_node
   else if is_strict_ancestor t ~ancestor:a ~descendant:b
   then Strict_ancestor
   else if is_strict_ancestor t ~ancestor:b ~descendant:a
   then Strict_descendant
-  else Unrelated
+  else Other
 ;;
 
 let tips t =

--- a/lib/vcs/src/tree.ml
+++ b/lib/vcs/src/tree.ml
@@ -434,3 +434,16 @@ let rec summary t =
   in
   { Summary.refs; roots = roots t |> List.map ~f:(fun id -> rev t id); tips; subtrees }
 ;;
+
+let check_index_exn t ~index =
+  let node_count = node_count t in
+  if index < 0 || index >= node_count
+  then raise_s [%sexp "Node index out of bounds", { index : int; node_count : int }]
+;;
+
+let get_node_exn t ~index =
+  check_index_exn t ~index;
+  (index :> Node.t)
+;;
+
+let node_index _ (node : Node.t) = (node :> int)

--- a/lib/vcs/src/tree.ml
+++ b/lib/vcs/src/tree.ml
@@ -122,7 +122,7 @@ let create () =
   }
 ;;
 
-let size t = Array.length t.nodes
+let node_count t = Array.length t.nodes
 let node_kind t node = t.nodes.(node)
 let ( .$() ) = node_kind
 let rev t node = Node_kind.rev t.$(node)

--- a/lib/vcs/src/tree.ml
+++ b/lib/vcs/src/tree.ml
@@ -303,11 +303,14 @@ let is_strict_ancestor t ~ancestor ~descendant =
        | Equal -> true
        | Greater -> loop to_visit
        | Less ->
-         if Hash_set.mem visited node
-         then loop to_visit
-         else (
-           Hash_set.add visited node;
-           loop (Node0.parents t node @ to_visit)))
+         let to_visit =
+           if Hash_set.mem visited node
+           then to_visit
+           else (
+             Hash_set.add visited node;
+             Node0.prepend_parents t node to_visit)
+         in
+         loop to_visit)
   in
   ancestor < descendant && loop [ descendant ]
 ;;

--- a/lib/vcs/src/tree.ml
+++ b/lib/vcs/src/tree.ml
@@ -123,8 +123,8 @@ let size t = Array.length t.nodes
 
 module Node0 = struct
   include Node_T
+  include Comparable.Make (Node_T)
 
-  let _ = hash_fold_t
   let rev t node = Node_kind.rev t.nodes.(node)
 
   let parents t node =

--- a/lib/vcs/src/tree.ml
+++ b/lib/vcs/src/tree.ml
@@ -119,6 +119,8 @@ let create () =
   }
 ;;
 
+let size t = Array.length t.nodes
+
 module Node0 = struct
   include Node_T
 

--- a/lib/vcs/src/tree.mli
+++ b/lib/vcs/src/tree.mli
@@ -134,8 +134,8 @@ end
 
 val descendance : t -> Node.t -> Node.t -> Descendance.t
 
-(** The size of a tree is defined as the number of nodes it currently holds. *)
-val size : t -> int
+(** Return the number of nodes the tree currently holds. *)
+val node_count : t -> int
 
 (** {1 Refs} *)
 

--- a/lib/vcs/src/tree.mli
+++ b/lib/vcs/src/tree.mli
@@ -88,10 +88,22 @@ end
 module Node : sig
   (** The node itself doesn't carry much information, rather it is simply a
       pointer to a location in the tree. Thus the functions of this interface
-      typically also require to be supplied the tree. *)
+      typically also require to be supplied the tree.
+
+      For convenience to users writing algorithms on git trees, the type [t]
+      exposes an efficient comparable interface, meaning you can e.g. manipulate
+      containers indexed by nodes.
+
+      An invariant that holds in the structure and on which you can rely is that
+      the parents of a node are always inserted in the tree before the node
+      itself (from left to right), and thus if [n1 > n2] (using the node
+      comparison function) then you can be certain that [n1] is not a parent of
+      [n2]. *)
 
   type tree := t
-  type t = node [@@deriving equal, sexp_of]
+  type t = node [@@deriving compare, equal, hash, sexp_of]
+
+  include Comparable.S with type t := t
 
   val rev : tree -> t -> Rev.t
 

--- a/lib/vcs/src/tree.mli
+++ b/lib/vcs/src/tree.mli
@@ -59,25 +59,24 @@ val set_refs : t -> refs:Refs.t -> unit
 (** Same as [set_refs], but one ref at a time. *)
 val set_ref : t -> rev:Rev.t -> ref_kind:Ref_kind.t -> unit
 
-(** {1 Nodes} *)
+(** {1 Nodes}
+
+    The node itself doesn't carry much information, rather it is simply a
+    pointer to a location in the tree. Thus the functions operating on nodes
+    typically also require to be supplied the tree.
+
+    For convenience to users writing algorithms on git trees, the type [t]
+    exposes an efficient comparable interface, meaning you can e.g. manipulate
+    containers indexed by nodes.
+
+    {1:ordering_invariant Ordering invariant}
+
+    An invariant that holds in the structure and on which you can rely is that
+    the parents of a node are always inserted in the tree before the node itself
+    (from left to right), and thus if [n1 > n2] (using the node comparison
+    function) then you can be certain that [n1] is not a parent of [n2]. *)
 
 module Node : sig
-  (** The node itself doesn't carry much information, rather it is simply a
-      pointer to a location in the tree. Thus the functions operating on nodes
-      typically also require to be supplied the tree.
-
-      For convenience to users writing algorithms on git trees, the type [t]
-      exposes an efficient comparable interface, meaning you can e.g. manipulate
-      containers indexed by nodes.
-
-      {1:ordering_invariant Ordering invariant}
-
-      An invariant that holds in the structure and on which you can rely is that
-      the parents of a node are always inserted in the tree before the node
-      itself (from left to right), and thus if [n1 > n2] (using the node
-      comparison function) then you can be certain that [n1] is not a parent of
-      [n2]. *)
-
   type t [@@deriving compare, equal, hash, sexp_of]
 
   include Comparable.S with type t := t

--- a/lib/vcs/src/tree.mli
+++ b/lib/vcs/src/tree.mli
@@ -125,10 +125,10 @@ module Descendance : sig
       useful for example when considering the status of a branch head with
       respect to its upstream counterpart. *)
   type t =
-    | Same
+    | Same_node
     | Strict_ancestor
     | Strict_descendant
-    | Unrelated
+    | Other
   [@@deriving equal, enumerate, hash, sexp_of]
 end
 

--- a/lib/vcs/src/tree.mli
+++ b/lib/vcs/src/tree.mli
@@ -36,7 +36,7 @@ type node
 
 type t [@@deriving sexp_of]
 
-(** create an empty tree that has no nodes. *)
+(** Create an empty tree that has no nodes. *)
 val create : unit -> t
 
 (** {1 Initializing the tree}
@@ -124,6 +124,9 @@ module Node : sig
 
   val descendance : tree -> t -> t -> Descendance.t
 end
+
+(** The size of a tree is defined as the number of nodes it currently holds. *)
+val size : t -> int
 
 (** {1 Refs} *)
 

--- a/lib/vcs/src/tree.mli
+++ b/lib/vcs/src/tree.mli
@@ -70,6 +70,8 @@ module Node : sig
       exposes an efficient comparable interface, meaning you can e.g. manipulate
       containers indexed by nodes.
 
+      {1:ordering_invariant Ordering invariant}
+
       An invariant that holds in the structure and on which you can rely is that
       the parents of a node are always inserted in the tree before the node
       itself (from left to right), and thus if [n1 > n2] (using the node
@@ -219,3 +221,19 @@ end
 
 (** Print a summary for use in expect test and quick exploratory tests *)
 val summary : t -> Summary.t
+
+(** {1 Low level node ordering}
+
+    This part of the interface is exposed for advanced usage only.
+
+    We make no guarantee about the stability of node ordering across vcs
+    versions. The order in which nodes be inserted is not fully specified,
+    outside of the ordering invariant discussed {{!ordering_invariant} here}. It
+    is considered to be only valid for the lifetime of the tree.
+
+    This is exposed if you want to write algorithms working on tree that take
+    advantage of operations working on int, if the rest of the exposed API isn't
+    enough for your use case. *)
+
+val get_node_exn : t -> index:int -> Node.t
+val node_index : t -> Node.t -> int

--- a/lib/vcs/test/test__tree.ml
+++ b/lib/vcs/test/test__tree.ml
@@ -313,14 +313,14 @@ let%expect_test "tree" =
         (Vcs.Tree.descendance tree (node_exn r1) (node_exn r2) : Vcs.Tree.Descendance.t)]
   in
   test tip tip;
-  [%expect {| Same |}];
+  [%expect {| Same_node |}];
   test tip root_node;
   [%expect {| Strict_descendant |}];
   test root_node tip;
   [%expect {| Strict_ancestor |}];
   let gh_page_tip = Vcs.Rev.v "7135b7f4790562e94d9122365478f0d39f5ffead" in
   test root_node gh_page_tip;
-  [%expect {| Unrelated |}];
+  [%expect {| Other |}];
   ()
 ;;
 

--- a/lib/vcs/test/test__tree.ml
+++ b/lib/vcs/test/test__tree.ml
@@ -35,11 +35,11 @@ let%expect_test "tree" =
     Vcs_git_cli.Refs.parse_lines_exn ~lines
   in
   let tree = Vcs.Tree.create () in
-  print_s [%sexp { size = (Vcs.Tree.size tree : int) }];
-  [%expect {| ((size 0)) |}];
+  print_s [%sexp { node_count = (Vcs.Tree.node_count tree : int) }];
+  [%expect {| ((node_count 0)) |}];
   Vcs.Tree.add_nodes tree ~log;
-  print_s [%sexp { size = (Vcs.Tree.size tree : int) }];
-  [%expect {| ((size 180)) |}];
+  print_s [%sexp { node_count = (Vcs.Tree.node_count tree : int) }];
+  [%expect {| ((node_count 180)) |}];
   List.iter refs ~f:(fun { rev; ref_kind } -> Vcs.Tree.set_ref tree ~rev ~ref_kind);
   let refs = Vcs.Tree.refs tree in
   List.iter refs ~f:(fun { rev; ref_kind } ->
@@ -621,9 +621,9 @@ let%expect_test "debug tree" =
              (remote_name origin)
              (branch_name main)))))))))
     |}];
-  (* size *)
-  print_s [%sexp { size = (Vcs.Tree.size tree : int) }];
-  [%expect {| ((size 5)) |}];
+  (* node_count *)
+  print_s [%sexp { node_count = (Vcs.Tree.node_count tree : int) }];
+  [%expect {| ((node_count 5)) |}];
   (* node_kind *)
   let node_kind rev =
     let node = node ~rev in

--- a/lib/vcs/test/test__tree.ml
+++ b/lib/vcs/test/test__tree.ml
@@ -667,5 +667,32 @@ let%expect_test "debug tree" =
   [%expect {| (#0 #1 #2 #3) |}];
   print_ancestors r4;
   [%expect {| (#0 #1 #2 #3 #4) |}];
+  (* Low level int indexing. *)
+  let node_index node = print_s [%sexp (Vcs.Tree.node_index tree node : int)] in
+  node_index (node ~rev:r1);
+  [%expect {| 0 |}];
+  node_index (node ~rev:r4);
+  [%expect {| 4 |}];
+  let get_node_exn index =
+    print_s [%sexp (Vcs.Tree.get_node_exn tree ~index : Vcs.Tree.Node.t)]
+  in
+  get_node_exn 0;
+  [%expect {| #0 |}];
+  get_node_exn 4;
+  [%expect {| #4 |}];
+  require_does_raise [%here] (fun () -> get_node_exn 5);
+  [%expect
+    {|
+    ("Node index out of bounds" (
+      (index      5)
+      (node_count 5)))
+    |}];
+  require_does_raise [%here] (fun () -> get_node_exn (-1));
+  [%expect
+    {|
+    ("Node index out of bounds" (
+      (index      -1)
+      (node_count 5)))
+    |}];
   ()
 ;;

--- a/lib/vcs/test/test__tree.ml
+++ b/lib/vcs/test/test__tree.ml
@@ -35,7 +35,11 @@ let%expect_test "tree" =
     Vcs_git_cli.Refs.parse_lines_exn ~lines
   in
   let tree = Vcs.Tree.create () in
+  print_s [%sexp { size = (Vcs.Tree.size tree : int) }];
+  [%expect {| ((size 0)) |}];
   Vcs.Tree.add_nodes tree ~log;
+  print_s [%sexp { size = (Vcs.Tree.size tree : int) }];
+  [%expect {| ((size 180)) |}];
   List.iter refs ~f:(fun { rev; ref_kind } -> Vcs.Tree.set_ref tree ~rev ~ref_kind);
   let refs = Vcs.Tree.refs tree in
   List.iter refs ~f:(fun { rev; ref_kind } ->
@@ -604,6 +608,9 @@ let%expect_test "debug tree" =
              (remote_name origin)
              (branch_name main)))))))))
     |}];
+  (* size *)
+  print_s [%sexp { size = (Vcs.Tree.size tree : int) }];
+  [%expect {| ((size 5)) |}];
   (* node_kind *)
   let node_kind rev =
     let node = node ~rev in

--- a/lib/vcs_command/src/vcs_command.ml
+++ b/lib/vcs_command/src/vcs_command.ml
@@ -320,7 +320,7 @@ let greatest_common_ancestors_cmd =
        in
        let gca =
          Vcs.Tree.greatest_common_ancestors tree nodes
-         |> List.map ~f:(fun node -> Vcs.Tree.Node.rev tree node)
+         |> List.map ~f:(fun node -> Vcs.Tree.rev tree node)
        in
        Eio_writer.print_sexp ~env [%sexp (gca : Vcs.Rev.t list)];
        return ())

--- a/test/expect/find_ref.ml
+++ b/test/expect/find_ref.ml
@@ -137,7 +137,7 @@ let%expect_test "find ref" =
   let sexp2 =
     let find_exn ref_kind =
       match Vcs.Tree.find_ref tree ~ref_kind with
-      | Some node -> Vcs.Mock_revs.to_mock mock_revs ~rev:(Vcs.Tree.Node.rev tree node)
+      | Some node -> Vcs.Mock_revs.to_mock mock_revs ~rev:(Vcs.Tree.rev tree node)
       | None -> assert false
     in
     lookup ~find_exn


### PR DESCRIPTION
## Changed

- Rename `Vcs.Descendance.t` constructors for clarity.
- Improve `Vcs.Tree.Node` interface.
