### PR TITLE
Remove base dependency (Vcs_base refactor)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
     "cSpell.words": [
+        "alphanum",
+        "astring",
         "chdir",
         "ENOENT",
         "fpath",
@@ -12,6 +14,8 @@
         "raise_notrace",
         "rmtree",
         "rresult",
+        "rsplit",
+        "Sexp_conv",
         "Stdenv",
         "subdir",
         "worktree",

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- Remove `base` dependency from `vcs` and provider libraries (#36, @mbarbin).
 - Moved `Or_error` related modules to `Vcs_base` (#35, @mbarbin).
 - Provider interfaces now uses `Vcs.Result` type instead of `Or_error` (#34, @mbarbin).
 - Rename what was `Vcs.Result` to `Vcs.Rresult` and introduce `Vcs.Result` whose type is simpler (#33, @mbarbin).

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -22,12 +22,44 @@ To spawn processes in `Eio` and collect their output we've copied some code from
 
 ### Notice
 
-The file where we make use of this code is `lib/vcs_git_eio/src/runtime.ml`. We've added a notice in the file and a comment next to the code that was copied and modified, which include `Eio_process`'s original LICENSE:
+The file where we make use of this code is `lib/vcs_git_eio/src/runtime.ml`. We've added a notice in the file and a comment next to the code that was copied and modified, which includes `Eio_process`'s original LICENSE:
 
 ```text
 MIT License
 
 Copyright (c) 2023 Mathieu Barbin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## A note about Base.String.split_lines
+
+We copied the implementation of the function `Base.String.split_lines` from the [Base](https://github.com/janestreet/base) project. `Base` is released under `MIT`.
+
+### Notice
+
+The file where we imported the function is `lib/vcs/src/import.ml`. We've added a notice in the file and a comment next to the code that was copied and modified, which includes `Base`'s original LICENSE:
+
+```text
+The MIT License
+
+Copyright (c) 2016--2024 Jane Street Group, LLC <opensource-contacts@janestreet.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/TODO.md
+++ b/TODO.md
@@ -45,14 +45,14 @@ Only keep sexp related ppx that have no runtime dependency on `base`, such as `s
 
 ### Stage 6 - Remove base dependency from `Vcs`
 
-- [ ] Pending
+- [x] Completed: Oct. 2024
 
 Use `vcs/src/import` to make a local mini-stdlib with utils required to remove `base` dependency.
 
 Do this for the other libraries:
 
-- [ ] vcs
-- [ ] vcs_command
-- [ ] vcs_git_blocking
-- [ ] vcs_git_eio
-- [ ] vcs_git_provider
+- [x] vcs
+- [x] vcs_command
+- [x] vcs_git_blocking
+- [x] vcs_git_eio
+- [x] vcs_git_provider

--- a/dune-project
+++ b/dune-project
@@ -23,10 +23,6 @@
  (depends
   (ocaml
    (>= 5.2))
-  (base
-   (and
-    (>= v0.17)
-    (< v0.18)))
   (fpath
    (>= 0.7.3))
   (fpath-sexp0
@@ -103,10 +99,6 @@
  (depends
   (ocaml
    (>= 5.2))
-  (base
-   (and
-    (>= v0.17)
-    (< v0.18)))
   (cmdlang
    (>= 0.0.5))
   (cmdlang-cmdliner-runner
@@ -133,6 +125,10 @@
     (< v0.18)))
   (ppxlib
    (>= 0.33))
+  (sexplib0
+   (and
+    (>= v0.17)
+    (< v0.18)))
   (vcs
    (= :version))
   (vcs-git-eio
@@ -144,10 +140,8 @@
  (depends
   (ocaml
    (>= 5.2))
-  (base
-   (and
-    (>= v0.17)
-    (< v0.18)))
+  (astring
+   (>= 0.8.5))
   (fpath
    (>= 0.7.3))
   (fpath-sexp0
@@ -162,6 +156,10 @@
     (< v0.18)))
   (ppxlib
    (>= 0.33))
+  (sexplib0
+   (and
+    (>= v0.17)
+    (< v0.18)))
   (vcs
    (= :version))))
 
@@ -172,10 +170,6 @@
  (depends
   (ocaml
    (>= 5.2))
-  (base
-   (and
-    (>= v0.17)
-    (< v0.18)))
   (eio
    (>= 1.0))
   (fpath
@@ -194,6 +188,10 @@
    (>= 0.33))
   (provider
    (>= 0.0.8))
+  (sexplib0
+   (and
+    (>= v0.17)
+    (< v0.18)))
   (vcs
    (= :version))
   (vcs-git-provider
@@ -206,10 +204,6 @@
  (depends
   (ocaml
    (>= 5.2))
-  (base
-   (and
-    (>= v0.17)
-    (< v0.18)))
   (fpath
    (>= 0.7.3))
   (fpath-sexp0
@@ -226,6 +220,10 @@
    (>= 0.33))
   (provider
    (>= 0.0.8))
+  (sexplib0
+   (and
+    (>= v0.17)
+    (< v0.18)))
   (vcs
    (= :version))
   (vcs-git-provider

--- a/dune-project
+++ b/dune-project
@@ -29,25 +29,9 @@
     (< v0.18)))
   (fpath
    (>= 0.7.3))
-  (fpath-base
+  (fpath-sexp0
    (>= 0.2.2))
-  (ppx_compare
-   (and
-    (>= v0.17)
-    (< v0.18)))
   (ppx_enumerate
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppx_hash
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppx_here
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppx_let
    (and
     (>= v0.17)
     (< v0.18)))
@@ -139,26 +123,6 @@
    (>= 0.7.3))
   (fpath-sexp0
    (>= 0.2.2))
-  (ppx_compare
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppx_enumerate
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppx_hash
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppx_here
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppx_let
-   (and
-    (>= v0.17)
-    (< v0.18)))
   (ppx_sexp_conv
    (and
     (>= v0.17)
@@ -188,26 +152,6 @@
    (>= 0.7.3))
   (fpath-sexp0
    (>= 0.2.2))
-  (ppx_compare
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppx_enumerate
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppx_hash
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppx_here
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppx_let
-   (and
-    (>= v0.17)
-    (< v0.18)))
   (ppx_sexp_conv
    (and
     (>= v0.17)
@@ -238,26 +182,6 @@
    (>= 0.7.3))
   (fpath-sexp0
    (>= 0.2.2))
-  (ppx_compare
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppx_enumerate
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppx_hash
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppx_here
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppx_let
-   (and
-    (>= v0.17)
-    (< v0.18)))
   (ppx_sexp_conv
    (and
     (>= v0.17)
@@ -290,26 +214,6 @@
    (>= 0.7.3))
   (fpath-sexp0
    (>= 0.2.2))
-  (ppx_compare
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppx_enumerate
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppx_hash
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppx_here
-   (and
-    (>= v0.17)
-    (< v0.18)))
-  (ppx_let
-   (and
-    (>= v0.17)
-    (< v0.18)))
   (ppx_sexp_conv
    (and
     (>= v0.17)

--- a/lib/vcs/src/container_key.ml
+++ b/lib/vcs/src/container_key.ml
@@ -37,6 +37,6 @@ module String_impl = struct
   let compare = compare_string
   let equal = equal_string
   let hash = hash_string
-  let seeded_hash = Stdlib.String.seeded_hash
+  let seeded_hash = String.seeded_hash
   let sexp_of_t = sexp_of_string
 end

--- a/lib/vcs/src/dune
+++ b/lib/vcs/src/dune
@@ -8,10 +8,12 @@
   -warn-error
   +a
   -open
-  Base
+  Fpath_sexp0
   -open
-  Fpath_sexp0)
- (libraries base fpath fpath-sexp0 provider)
+  Sexplib0
+  -open
+  Sexplib0.Sexp_conv)
+ (libraries fpath fpath-sexp0 provider)
  (instrumentation
   (backend bisect_ppx))
  (lint

--- a/lib/vcs/src/dune
+++ b/lib/vcs/src/dune
@@ -10,8 +10,8 @@
   -open
   Base
   -open
-  Fpath_base)
- (libraries base fpath fpath-base provider)
+  Fpath_sexp0)
+ (libraries base fpath fpath-sexp0 provider)
  (instrumentation
   (backend bisect_ppx))
  (lint

--- a/lib/vcs/src/import.ml
+++ b/lib/vcs/src/import.ml
@@ -19,10 +19,302 @@
 (*  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*******************************************************************************)
 
-module Result = struct
-  include Result
+module Array = struct
+  include ArrayLabels
 
-  module Monad_syntax = struct
-    let ( let* ) = Stdlib.Result.bind
+  let create ~len a = make len a
+
+  let filter_mapi t ~f =
+    let out_count = ref 0 in
+    let out = ref [] in
+    iteri t ~f:(fun i a ->
+      match f i a with
+      | None -> ()
+      | Some e ->
+        incr out_count;
+        out := e :: !out);
+    match !out with
+    | [] -> [||]
+    | hd :: _ ->
+      let out_count = !out_count in
+      let res = create ~len:out_count hd in
+      List.iteri (fun i a -> res.(out_count - 1 - i) <- a) !out;
+      res
+  ;;
+
+  let rev a =
+    let len = length a in
+    let res = create ~len a.(0) in
+    iteri a ~f:(fun i x -> res.(len - 1 - i) <- x);
+    res
+  ;;
+
+  let sort t ~compare = sort t ~cmp:compare
+end
+
+module Char = struct
+  include Char
+
+  let is_alphanum = function
+    | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' -> true
+    | _ -> false
+  ;;
+
+  let is_whitespace = function
+    | '\t' | '\n' | '\011' (* vertical tab *) | '\012' (* form feed *) | '\r' | ' ' ->
+      true
+    | _ -> false
+  ;;
+end
+
+module Hashtbl = struct
+  include (
+    MoreLabels.Hashtbl :
+      module type of MoreLabels.Hashtbl with module Make := MoreLabels.Hashtbl.Make)
+
+  module type S_extended = sig
+    include MoreLabels.Hashtbl.S
+
+    val add_exn : 'a t -> key:key -> data:'a -> unit
+    val add_multi : 'a list t -> key:key -> data:'a -> unit
+    val find : 'a t -> key -> 'a option
+    val set : 'a t -> key:key -> data:'a -> unit
+  end
+
+  exception E of Sexp.t
+
+  let () =
+    Sexplib0.Sexp_conv.Exn_converter.add [%extension_constructor E] (function
+      | E sexp -> sexp
+      | _ -> assert false)
+  ;;
+
+  module Make (H : sig
+      include Hashtbl.HashedType
+
+      val sexp_of_t : t -> Sexp.t
+    end) =
+  struct
+    include MoreLabels.Hashtbl.Make (H)
+
+    let add_exn t ~key ~data =
+      if mem t key
+      then raise (E [%sexp "Hashtbl.add_exn: key already present", { key : H.t }])
+      else add t ~key ~data
+    ;;
+
+    let add_multi t ~key ~data =
+      let data =
+        match find_opt t key with
+        | None -> [ data ]
+        | Some l -> data :: l
+      in
+      replace t ~key ~data
+    ;;
+
+    let find = find_opt
+    let set = replace
   end
 end
+
+module Int = struct
+  include Int
+
+  let incr = incr
+  let max_value = max_int
+
+  let of_string s =
+    try int_of_string s with
+    | _ -> failwith (Printf.sprintf "Int.of_string: %S" s)
+  ;;
+
+  let of_string_opt = int_of_string_opt
+
+  let to_string_hum n =
+    let s = string_of_int n in
+    let len = String.length s in
+    let is_negative = n < 0 in
+    let sign_count = if is_negative then 1 else 0 in
+    let absolute_digit_count = if is_negative then len - 1 else len in
+    let separator_count = absolute_digit_count / 3 in
+    let initial_skip_count =
+      let digit_skip = absolute_digit_count mod 3 in
+      sign_count + if digit_skip > 0 then digit_skip else 3
+    in
+    let buffer = Buffer.create (len + separator_count) in
+    let rec aux i count =
+      if i < len
+      then
+        if count = 0
+        then (
+          Buffer.add_char buffer '_';
+          aux i 3)
+        else (
+          Buffer.add_char buffer s.[i];
+          aux (i + 1) (count - 1))
+    in
+    aux 0 initial_skip_count;
+    Buffer.contents buffer
+  ;;
+end
+
+module List = struct
+  include ListLabels
+
+  let dedup_and_sort t ~compare = sort_uniq t ~cmp:compare
+
+  let hd = function
+    | [] -> None
+    | hd :: _ -> Some hd
+  ;;
+
+  let filter_opt t = filter_map t ~f:Fun.id
+  let find t ~f = find_opt t ~f
+  let fold t ~init ~f = fold_left ~f ~init t
+  let sort t ~compare = sort t ~cmp:compare
+end
+
+module Option = struct
+  include Option
+
+  let map t ~f = map f t
+  let some_if cond a = if cond then Some a else None
+end
+
+module Ordering = struct
+  include Provider.Private.Import.Ordering
+end
+
+module Queue = struct
+  include Queue
+
+  let enqueue t a = push a t
+  let to_list t = t |> to_seq |> List.of_seq
+end
+
+module Result = struct
+  type ('a, 'b) t = ('a, 'b) Result.t =
+    | Ok of 'a
+    | Error of 'b
+  [@@deriving sexp_of]
+
+  include (Result : module type of Result with type ('a, 'b) t := ('a, 'b) t)
+
+  module Monad_syntax = struct
+    let ( let* ) = Result.bind
+  end
+
+  let map t ~f = map f t
+  let map_error t ~f = map_error f t
+
+  let of_option t ~error =
+    match t with
+    | Some v -> Ok v
+    | None -> Error error
+  ;;
+
+  let return = ok
+end
+
+module String = struct
+  include StringLabels
+
+  let chop_prefix t ~prefix =
+    if Astring.String.is_prefix t ~affix:prefix
+    then Some (Astring.String.with_index_range t ~first:(String.length prefix))
+    else None
+  ;;
+
+  let chop_suffix t ~suffix =
+    if Astring.String.is_suffix t ~affix:suffix
+    then
+      Some
+        (Astring.String.with_index_range
+           t
+           ~last:(String.length t - String.length suffix - 1))
+    else None
+  ;;
+
+  let init len ~f = String.init len f
+  let is_empty = Astring.String.is_empty
+  let lsplit2 t ~on = Astring.String.cut ~sep:(String.make 1 on) t
+  let rsplit2 t ~on = Astring.String.cut ~sep:(String.make 1 on) t ~rev:true
+
+  (* The function [split_lines] below was copied from [Base.String0.split_lines]
+     version [v0.17] which is released under MIT and may be found at
+     [https://github.com/janestreet/base].
+
+     The changes we made were minimal:
+
+     - Changed references to [Char0] to [Char].
+
+     See Base's LICENSE below:
+
+     ----------------------------------------------------------------------------
+
+     The MIT License
+
+     Copyright (c) 2016--2024 Jane Street Group, LLC <opensource-contacts@janestreet.com>
+
+     Permission is hereby granted, free of charge, to any person obtaining a copy
+     of this software and associated documentation files (the "Software"), to deal
+     in the Software without restriction, including without limitation the rights
+     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+     copies of the Software, and to permit persons to whom the Software is
+     furnished to do so, subject to the following conditions:
+
+     The above copyright notice and this permission notice shall be included in all
+     copies or substantial portions of the Software.
+
+     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+     SOFTWARE. *)
+
+  let split_lines =
+    let back_up_at_newline ~t ~pos ~eol =
+      pos := !pos - if !pos > 0 && Char.equal t.[!pos - 1] '\r' then 2 else 1;
+      eol := !pos + 1
+    in
+    fun t ->
+      let n = length t in
+      if n = 0
+      then []
+      else (
+        (* Invariant: [-1 <= pos < eol]. *)
+        let pos = ref (n - 1) in
+        let eol = ref n in
+        let ac = ref [] in
+        (* We treat the end of the string specially, because if the string ends with a
+           newline, we don't want an extra empty string at the end of the output. *)
+        if Char.equal t.[!pos] '\n' then back_up_at_newline ~t ~pos ~eol;
+        while !pos >= 0 do
+          if not (Char.equal t.[!pos] '\n')
+          then decr pos
+          else (
+            (* Because [pos < eol], we know that [start <= eol]. *)
+            let start = !pos + 1 in
+            ac := sub t ~pos:start ~len:(!eol - start) :: !ac;
+            back_up_at_newline ~t ~pos ~eol)
+        done;
+        sub t ~pos:0 ~len:!eol :: !ac)
+  ;;
+
+  (* ---------------------------------------------------------------------------- *)
+
+  let split t ~on = split_on_char ~sep:on t
+  let strip = trim
+  let uncapitalize = uncapitalize_ascii
+end
+
+let compare_bool = Bool.compare
+let compare_int = Int.compare
+let compare_string = String.compare
+let equal_bool = Bool.equal
+let equal_int = Int.equal
+let equal_string = String.equal
+let equal_list eq a b = List.equal ~eq a b
+let hash_string = String.hash

--- a/lib/vcs/src/import.mli
+++ b/lib/vcs/src/import.mli
@@ -19,10 +19,119 @@
 (*_  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*_******************************************************************************)
 
+module Array : sig
+  include module type of ArrayLabels
+
+  val create : len:int -> 'a -> 'a array
+  val filter_mapi : 'a array -> f:(int -> 'a -> 'b option) -> 'b array
+  val rev : 'a array -> 'a array
+  val sort : 'a array -> compare:('a -> 'a -> int) -> unit
+end
+
+module Char : sig
+  include module type of Char
+
+  val is_alphanum : char -> bool
+  val is_whitespace : char -> bool
+end
+
+module Hashtbl : sig
+  include module type of MoreLabels.Hashtbl with module Make := MoreLabels.Hashtbl.Make
+
+  module type S_extended = sig
+    include MoreLabels.Hashtbl.S
+
+    val add_exn : 'a t -> key:key -> data:'a -> unit
+    val add_multi : 'a list t -> key:key -> data:'a -> unit
+    val find : 'a t -> key -> 'a option
+    val set : 'a t -> key:key -> data:'a -> unit
+  end
+
+  module Make (H : sig
+      include Hashtbl.HashedType
+
+      val sexp_of_t : t -> Sexp.t
+    end) : S_extended with type key = H.t
+end
+
+module Int : sig
+  include module type of Int
+
+  val incr : int ref -> unit
+  val max_value : int
+  val of_string : string -> int
+  val of_string_opt : string -> int option
+  val to_string_hum : int -> string
+end
+
+module List : sig
+  include module type of ListLabels
+
+  val dedup_and_sort : 'a list -> compare:('a -> 'a -> int) -> 'a list
+  val filter_opt : 'a option list -> 'a list
+  val find : 'a list -> f:('a -> bool) -> 'a option
+  val fold : 'a list -> init:'b -> f:('b -> 'a -> 'b) -> 'b
+  val hd : 'a list -> 'a option
+  val sort : 'a list -> compare:('a -> 'a -> int) -> 'a list
+end
+
+module Option : sig
+  include module type of Option
+
+  val map : 'a option -> f:('a -> 'b) -> 'b option
+  val some_if : bool -> 'a -> 'a option
+end
+
+module Ordering : sig
+  type t =
+    | Less
+    | Equal
+    | Greater
+
+  val of_int : int -> t
+end
+
+module Queue : sig
+  include module type of Queue
+
+  val enqueue : 'a t -> 'a -> unit
+  val to_list : 'a t -> 'a list
+end
+
 module Result : sig
   include module type of Result
 
   module Monad_syntax : sig
     val ( let* ) : ('a, 'e) t -> ('a -> ('b, 'e) t) -> ('b, 'e) t
   end
+
+  val sexp_of_t : ('a -> Sexp.t) -> ('b -> Sexp.t) -> ('a, 'b) Result.t -> Sexp.t
+  val map : ('a, 'e) Result.t -> f:('a -> 'b) -> ('b, 'e) Result.t
+  val map_error : ('a, 'e1) Result.t -> f:('e1 -> 'e2) -> ('a, 'e2) Result.t
+  val of_option : 'a option -> error:'e -> ('a, 'e) Result.t
+  val return : 'a -> ('a, _) Result.t
 end
+
+module String : sig
+  include module type of StringLabels
+
+  val chop_prefix : string -> prefix:string -> string option
+  val chop_suffix : string -> suffix:string -> string option
+  val init : int -> f:(int -> char) -> string
+  val is_empty : string -> bool
+  val lsplit2 : string -> on:char -> (string * string) option
+  val rsplit2 : string -> on:char -> (string * string) option
+  val split_lines : string -> string list
+  val split : string -> on:char -> string list
+  val strip : string -> string
+  val uncapitalize : string -> string
+end
+
+val compare_bool : bool -> bool -> int
+val compare_int : int -> int -> int
+val compare_string : string -> string -> int
+val equal_bool : bool -> bool -> bool
+val equal_int : int -> int -> bool
+val equal_string : string -> string -> bool
+val equal_list : ('a -> 'a -> bool) -> 'a list -> 'a list -> bool
+val hash_string : string -> int

--- a/lib/vcs/src/int_table.ml
+++ b/lib/vcs/src/int_table.ml
@@ -19,15 +19,8 @@
 (*  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*******************************************************************************)
 
-open! Import
+include Import.Hashtbl.Make (struct
+    include Int
 
-type t = GitHub [@@deriving enumerate, sexp_of]
-
-let compare = (compare : t -> t -> int)
-let equal = (( = ) : t -> t -> bool)
-let seeded_hash = (Hashtbl.seeded_hash : int -> t -> int)
-let hash = (Hashtbl.hash : t -> int)
-
-let to_string = function
-  | GitHub -> "GitHub"
-;;
+    let sexp_of_t t = Sexp.Atom (Import.Int.to_string_hum t)
+  end)

--- a/lib/vcs/src/int_table.mli
+++ b/lib/vcs/src/int_table.mli
@@ -19,9 +19,4 @@
 (*_  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*_******************************************************************************)
 
-type t = Vcs.Num_lines_in_diff.t =
-  { insertions : int
-  ; deletions : int
-  }
-
-include module type of Vcs.Num_lines_in_diff with type t := t
+include Import.Hashtbl.S_extended with type key = int

--- a/lib/vcs/src/log.ml
+++ b/lib/vcs/src/log.ml
@@ -39,7 +39,7 @@ module Line = struct
 
   let equal =
     (fun a__001_ b__002_ ->
-       if Stdlib.( == ) a__001_ b__002_
+       if a__001_ == b__002_
        then true
        else (
          match a__001_, b__002_ with
@@ -47,17 +47,14 @@ module Line = struct
          | Root _, _ -> false
          | _, Root _ -> false
          | Commit _a__005_, Commit _b__006_ ->
-           Stdlib.( && )
-             (Rev.equal _a__005_.rev _b__006_.rev)
-             (Rev.equal _a__005_.parent _b__006_.parent)
+           Rev.equal _a__005_.rev _b__006_.rev
+           && Rev.equal _a__005_.parent _b__006_.parent
          | Commit _, _ -> false
          | _, Commit _ -> false
          | Merge _a__007_, Merge _b__008_ ->
-           Stdlib.( && )
-             (Rev.equal _a__007_.rev _b__008_.rev)
-             (Stdlib.( && )
-                (Rev.equal _a__007_.parent1 _b__008_.parent1)
-                (Rev.equal _a__007_.parent2 _b__008_.parent2)))
+           Rev.equal _a__007_.rev _b__008_.rev
+           && Rev.equal _a__007_.parent1 _b__008_.parent1
+           && Rev.equal _a__007_.parent2 _b__008_.parent2)
      : t -> t -> bool)
   ;;
 
@@ -77,9 +74,8 @@ end
 include T
 
 let roots (t : t) =
-  let queue = Queue.create () in
-  List.iter t ~f:(function
-    | Root { rev } -> Queue.enqueue queue rev
-    | Commit _ | Merge _ -> ());
-  Queue.to_list queue
+  List.filter_map t ~f:(fun line ->
+    match (line : Line.t) with
+    | Root { rev } -> Some rev
+    | Commit _ | Merge _ -> None)
 ;;

--- a/lib/vcs/src/mock_rev_gen.ml
+++ b/lib/vcs/src/mock_rev_gen.ml
@@ -39,7 +39,7 @@ let next (t : t) =
   let i = t.counter in
   t.counter <- i + 1;
   let seed = Printf.sprintf "%d virtual-rev %s %d" i t.name i in
-  let hex = seed |> Stdlib.Digest.string |> Stdlib.Digest.to_hex in
-  let rev = String.init 40 ~f:(fun i -> hex.[i % String.length hex]) in
+  let hex = seed |> Digest.string |> Digest.to_hex in
+  let rev = String.init 40 ~f:(fun i -> hex.[i mod String.length hex]) in
   Rev.v rev
 ;;

--- a/lib/vcs/src/mock_revs.ml
+++ b/lib/vcs/src/mock_revs.ml
@@ -20,28 +20,26 @@
 (*******************************************************************************)
 
 type t =
-  { of_mock : Rev.t Hashtbl.M(Rev).t
-  ; to_mock : Rev.t Hashtbl.M(Rev).t
+  { of_mock : Rev.t Rev_table.t
+  ; to_mock : Rev.t Rev_table.t
   ; mock_rev_gen : Mock_rev_gen.t
   }
 
 let create () =
   let mock_rev_gen = Mock_rev_gen.create ~name:"mock-revs" in
-  { of_mock = Hashtbl.create (module Rev)
-  ; to_mock = Hashtbl.create (module Rev)
-  ; mock_rev_gen
-  }
+  let size = 17 in
+  { of_mock = Rev_table.create size; to_mock = Rev_table.create size; mock_rev_gen }
 ;;
 
 let next t = Mock_rev_gen.next t.mock_rev_gen
 
 let add_exn t ~rev ~mock_rev =
-  Hashtbl.add_exn t.to_mock ~key:rev ~data:mock_rev;
-  Hashtbl.add_exn t.of_mock ~key:mock_rev ~data:rev
+  Rev_table.add_exn t.to_mock ~key:rev ~data:mock_rev;
+  Rev_table.add_exn t.of_mock ~key:mock_rev ~data:rev
 ;;
 
 let to_mock t ~rev =
-  match Hashtbl.find t.to_mock rev with
+  match Rev_table.find t.to_mock rev with
   | Some rev -> rev
   | None ->
     let mock_rev = next t in
@@ -49,4 +47,4 @@ let to_mock t ~rev =
     mock_rev
 ;;
 
-let of_mock t ~mock_rev = Hashtbl.find t.of_mock mock_rev
+let of_mock t ~mock_rev = Rev_table.find t.of_mock mock_rev

--- a/lib/vcs/src/name_status.ml
+++ b/lib/vcs/src/name_status.ml
@@ -66,7 +66,7 @@ module Change = struct
 
   let equal =
     (fun a__001_ b__002_ ->
-       if Stdlib.( == ) a__001_ b__002_
+       if a__001_ == b__002_
        then true
        else (
          match a__001_, b__002_ with
@@ -80,19 +80,15 @@ module Change = struct
          | Modified _, _ -> false
          | _, Modified _ -> false
          | Copied _a__009_, Copied _b__010_ ->
-           Stdlib.( && )
-             (Path_in_repo.equal _a__009_.src _b__010_.src)
-             (Stdlib.( && )
-                (Path_in_repo.equal _a__009_.dst _b__010_.dst)
-                (equal_int _a__009_.similarity _b__010_.similarity))
+           Path_in_repo.equal _a__009_.src _b__010_.src
+           && Path_in_repo.equal _a__009_.dst _b__010_.dst
+           && equal_int _a__009_.similarity _b__010_.similarity
          | Copied _, _ -> false
          | _, Copied _ -> false
          | Renamed _a__011_, Renamed _b__012_ ->
-           Stdlib.( && )
-             (Path_in_repo.equal _a__011_.src _b__012_.src)
-             (Stdlib.( && )
-                (Path_in_repo.equal _a__011_.dst _b__012_.dst)
-                (equal_int _a__011_.similarity _b__012_.similarity)))
+           Path_in_repo.equal _a__011_.src _b__012_.src
+           && Path_in_repo.equal _a__011_.dst _b__012_.dst
+           && equal_int _a__011_.similarity _b__012_.similarity)
      : t -> t -> bool)
   ;;
 end
@@ -146,14 +142,12 @@ module Changed = struct
 
   let equal =
     (fun a__034_ b__035_ ->
-       if Stdlib.( == ) a__034_ b__035_
+       if a__034_ == b__035_
        then true
        else (
          match a__034_, b__035_ with
          | Between _a__036_, Between _b__037_ ->
-           Stdlib.( && )
-             (Rev.equal _a__036_.src _b__037_.src)
-             (Rev.equal _a__036_.dst _b__037_.dst))
+           Rev.equal _a__036_.src _b__037_.src && Rev.equal _a__036_.dst _b__037_.dst)
      : t -> t -> bool)
   ;;
 end

--- a/lib/vcs/src/num_lines_in_diff.ml
+++ b/lib/vcs/src/num_lines_in_diff.ml
@@ -30,7 +30,7 @@ module T = struct
 
   let compare =
     (fun a__001_ b__002_ ->
-       if Stdlib.( == ) a__001_ b__002_
+       if a__001_ == b__002_
        then 0
        else (
          match compare_int a__001_.insertions b__002_.insertions with
@@ -41,12 +41,11 @@ module T = struct
 
   let equal =
     (fun a__003_ b__004_ ->
-       if Stdlib.( == ) a__003_ b__004_
+       if a__003_ == b__004_
        then true
        else
-         Stdlib.( && )
-           (equal_int a__003_.insertions b__004_.insertions)
-           (equal_int a__003_.deletions b__004_.deletions)
+         equal_int a__003_.insertions b__004_.insertions
+         && equal_int a__003_.deletions b__004_.deletions
      : t -> t -> bool)
   ;;
 
@@ -61,10 +60,10 @@ end
 
 include T
 
-let sum ts = List.sum (module T) ts ~f:Fn.id
+let sum ts = List.fold ts ~init:T.zero ~f:T.( + )
 
 let to_string_hum { insertions; deletions } =
-  let int_hum i = Int.to_string_hum ~delimiter:',' i in
+  let int_hum i = Int.to_string_hum i in
   match
     [ (if insertions > 0 then Some ("+" ^ int_hum insertions) else None)
     ; (if deletions > 0 then Some ("-" ^ int_hum deletions) else None)
@@ -77,5 +76,5 @@ let to_string_hum { insertions; deletions } =
   | _ :: _ :: _ :: _ -> assert false
 ;;
 
-let total { insertions; deletions } = Int.( + ) insertions deletions
+let total { insertions; deletions } = Int.add insertions deletions
 let is_zero { insertions; deletions } = insertions = 0 && deletions = 0

--- a/lib/vcs/src/num_status.ml
+++ b/lib/vcs/src/num_status.ml
@@ -34,7 +34,7 @@ module Key = struct
 
   let compare =
     (fun a__001_ b__002_ ->
-       if Stdlib.( == ) a__001_ b__002_
+       if a__001_ == b__002_
        then 0
        else (
          match a__001_, b__002_ with
@@ -50,7 +50,7 @@ module Key = struct
 
   let equal =
     (fun a__007_ b__008_ ->
-       if Stdlib.( == ) a__007_ b__008_
+       if a__007_ == b__008_
        then true
        else (
          match a__007_, b__008_ with
@@ -58,14 +58,13 @@ module Key = struct
          | One_file _, _ -> false
          | _, One_file _ -> false
          | Two_files _a__011_, Two_files _b__012_ ->
-           Stdlib.( && )
-             (Path_in_repo.equal _a__011_.src _b__012_.src)
-             (Path_in_repo.equal _a__011_.dst _b__012_.dst))
+           Path_in_repo.equal _a__011_.src _b__012_.src
+           && Path_in_repo.equal _a__011_.dst _b__012_.dst)
      : t -> t -> bool)
   ;;
 
-  let seeded_hash = (Stdlib.Hashtbl.seeded_hash : int -> t -> int)
-  let hash = (Stdlib.Hashtbl.hash : t -> int)
+  let seeded_hash = (Hashtbl.seeded_hash : int -> t -> int)
+  let hash = (Hashtbl.hash : t -> int)
 end
 
 module Change = struct
@@ -79,7 +78,7 @@ module Change = struct
 
     let equal =
       (fun a__008_ b__009_ ->
-         if Stdlib.( == ) a__008_ b__009_
+         if a__008_ == b__009_
          then true
          else (
            match a__008_, b__009_ with
@@ -100,12 +99,11 @@ module Change = struct
 
   let equal =
     (fun a__014_ b__015_ ->
-       if Stdlib.( == ) a__014_ b__015_
+       if a__014_ == b__015_
        then true
        else
-         Stdlib.( && )
-           (Key.equal a__014_.key b__015_.key)
-           (Num_stat.equal a__014_.num_stat b__015_.num_stat)
+         Key.equal a__014_.key b__015_.key
+         && Num_stat.equal a__014_.num_stat b__015_.num_stat
      : t -> t -> bool)
   ;;
 end
@@ -128,14 +126,12 @@ module Changed = struct
 
   let equal =
     (fun a__022_ b__023_ ->
-       if Stdlib.( == ) a__022_ b__023_
+       if a__022_ == b__023_
        then true
        else (
          match a__022_, b__023_ with
          | Between _a__024_, Between _b__025_ ->
-           Stdlib.( && )
-             (Rev.equal _a__024_.src _b__025_.src)
-             (Rev.equal _a__024_.dst _b__025_.dst))
+           Rev.equal _a__024_.src _b__025_.src && Rev.equal _a__024_.dst _b__025_.dst)
      : t -> t -> bool)
   ;;
 end

--- a/lib/vcs/src/ref_kind.ml
+++ b/lib/vcs/src/ref_kind.ml
@@ -32,7 +32,7 @@ type t =
 
 let compare =
   (fun a__001_ b__002_ ->
-     if Stdlib.( == ) a__001_ b__002_
+     if a__001_ == b__002_
      then 0
      else (
        match a__001_, b__002_ with
@@ -56,7 +56,7 @@ let compare =
 
 let equal =
   (fun a__011_ b__012_ ->
-     if Stdlib.( == ) a__011_ b__012_
+     if a__011_ == b__012_
      then true
      else (
        match a__011_, b__012_ with
@@ -75,8 +75,8 @@ let equal =
    : t -> t -> bool)
 ;;
 
-let seeded_hash = (Stdlib.Hashtbl.seeded_hash : int -> t -> int)
-let hash = (Stdlib.Hashtbl.hash : t -> int)
+let seeded_hash = (Hashtbl.seeded_hash : int -> t -> int)
+let hash = (Hashtbl.hash : t -> int)
 
 let to_string = function
   | Local_branch { branch_name } -> "refs/heads/" ^ Branch_name.to_string branch_name

--- a/lib/vcs/src/ref_kind_table.ml
+++ b/lib/vcs/src/ref_kind_table.ml
@@ -19,15 +19,4 @@
 (*  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*******************************************************************************)
 
-open! Import
-
-type t = GitHub [@@deriving enumerate, sexp_of]
-
-let compare = (compare : t -> t -> int)
-let equal = (( = ) : t -> t -> bool)
-let seeded_hash = (Hashtbl.seeded_hash : int -> t -> int)
-let hash = (Hashtbl.hash : t -> int)
-
-let to_string = function
-  | GitHub -> "GitHub"
-;;
+include Import.Hashtbl.Make (Ref_kind)

--- a/lib/vcs/src/ref_kind_table.mli
+++ b/lib/vcs/src/ref_kind_table.mli
@@ -19,9 +19,4 @@
 (*_  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*_******************************************************************************)
 
-type t = Vcs.Num_lines_in_diff.t =
-  { insertions : int
-  ; deletions : int
-  }
-
-include module type of Vcs.Num_lines_in_diff with type t := t
+include Import.Hashtbl.S_extended with type key = Ref_kind.t

--- a/lib/vcs/src/refs.ml
+++ b/lib/vcs/src/refs.ml
@@ -32,12 +32,11 @@ module Line = struct
 
   let equal =
     (fun a__001_ b__002_ ->
-       if Stdlib.( == ) a__001_ b__002_
+       if a__001_ == b__002_
        then true
        else
-         Stdlib.( && )
-           (Rev.equal a__001_.rev b__002_.rev)
-           (Ref_kind.equal a__001_.ref_kind b__002_.ref_kind)
+         Rev.equal a__001_.rev b__002_.rev
+         && Ref_kind.equal a__001_.ref_kind b__002_.ref_kind
      : t -> t -> bool)
   ;;
 end
@@ -54,21 +53,21 @@ include T
 
 let tags (t : t) =
   List.filter_map t ~f:(function
-    | { rev = _; ref_kind = Tag { tag_name } } -> Some tag_name
+    | { Line.rev = _; ref_kind = Tag { tag_name } } -> Some tag_name
     | _ -> None)
   |> List.sort ~compare:Tag_name.compare
 ;;
 
 let local_branches (t : t) =
   List.filter_map t ~f:(function
-    | { rev = _; ref_kind = Local_branch { branch_name } } -> Some branch_name
+    | { Line.rev = _; ref_kind = Local_branch { branch_name } } -> Some branch_name
     | _ -> None)
   |> List.sort ~compare:Branch_name.compare
 ;;
 
 let remote_branches (t : t) =
   List.filter_map t ~f:(function
-    | { rev = _; ref_kind = Remote_branch { remote_branch_name } } ->
+    | { Line.rev = _; ref_kind = Remote_branch { remote_branch_name } } ->
       Some remote_branch_name
     | _ -> None)
   |> List.sort ~compare:Remote_branch_name.compare

--- a/lib/vcs/src/remote_branch_name.ml
+++ b/lib/vcs/src/remote_branch_name.ml
@@ -31,7 +31,7 @@ type t =
 
 let compare =
   (fun a__001_ b__002_ ->
-     if Stdlib.( == ) a__001_ b__002_
+     if a__001_ == b__002_
      then 0
      else (
        match Remote_name.compare a__001_.remote_name b__002_.remote_name with
@@ -42,19 +42,18 @@ let compare =
 
 let equal =
   (fun a__003_ b__004_ ->
-     if Stdlib.( == ) a__003_ b__004_
+     if a__003_ == b__004_
      then true
      else
-       Stdlib.( && )
-         (Remote_name.equal a__003_.remote_name b__004_.remote_name)
-         (Branch_name.equal a__003_.branch_name b__004_.branch_name)
+       Remote_name.equal a__003_.remote_name b__004_.remote_name
+       && Branch_name.equal a__003_.branch_name b__004_.branch_name
    : t -> t -> bool)
 ;;
 
 [@@@coverage on]
 
-let seeded_hash = (Stdlib.Hashtbl.seeded_hash : int -> t -> int)
-let hash = (Stdlib.Hashtbl.hash : t -> int)
+let seeded_hash = (Hashtbl.seeded_hash : int -> t -> int)
+let hash = (Hashtbl.hash : t -> int)
 
 let to_string { remote_name; branch_name } =
   Printf.sprintf

--- a/lib/vcs/src/rev.ml
+++ b/lib/vcs/src/rev.ml
@@ -23,8 +23,8 @@ open! Import
 include Container_key.String_impl
 
 let invariant t =
-  Int.(String.length t = 40)
-  && String.for_all t ~f:(fun c -> Char.is_alphanum c || Char.(c = '-'))
+  Int.equal (String.length t) 40
+  && String.for_all t ~f:(fun c -> Char.is_alphanum c || Char.equal c '-')
 ;;
 
 include Validated_string.Make (struct

--- a/lib/vcs/src/rev_table.ml
+++ b/lib/vcs/src/rev_table.ml
@@ -19,15 +19,4 @@
 (*  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*******************************************************************************)
 
-open! Import
-
-type t = GitHub [@@deriving enumerate, sexp_of]
-
-let compare = (compare : t -> t -> int)
-let equal = (( = ) : t -> t -> bool)
-let seeded_hash = (Hashtbl.seeded_hash : int -> t -> int)
-let hash = (Hashtbl.hash : t -> int)
-
-let to_string = function
-  | GitHub -> "GitHub"
-;;
+include Import.Hashtbl.Make (Rev)

--- a/lib/vcs/src/rev_table.mli
+++ b/lib/vcs/src/rev_table.mli
@@ -19,9 +19,4 @@
 (*_  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*_******************************************************************************)
 
-type t = Vcs.Num_lines_in_diff.t =
-  { insertions : int
-  ; deletions : int
-  }
-
-include module type of Vcs.Num_lines_in_diff with type t := t
+include Import.Hashtbl.S_extended with type key = Rev.t

--- a/lib/vcs/src/url.ml
+++ b/lib/vcs/src/url.ml
@@ -29,13 +29,13 @@ module Protocol = struct
     | Https
   [@@deriving enumerate, sexp_of]
 
-  let compare = (Stdlib.compare : t -> t -> int)
-  let equal = (Stdlib.( = ) : t -> t -> bool)
+  let compare = (compare : t -> t -> int)
+  let equal = (( = ) : t -> t -> bool)
 
   [@@@coverage on]
 
-  let seeded_hash = (Stdlib.Hashtbl.seeded_hash : int -> t -> int)
-  let hash = (Stdlib.Hashtbl.hash : t -> int)
+  let seeded_hash = (Hashtbl.seeded_hash : int -> t -> int)
+  let hash = (Hashtbl.hash : t -> int)
 
   let to_string t ~(platform : Platform.t) =
     match platform, t with
@@ -56,7 +56,7 @@ type t =
 
 let compare =
   (fun a__005_ b__006_ ->
-     if Stdlib.( == ) a__005_ b__006_
+     if a__005_ == b__006_
      then 0
      else (
        match Platform.compare a__005_.platform b__006_.platform with
@@ -73,23 +73,20 @@ let compare =
 
 let equal =
   (fun a__007_ b__008_ ->
-     if Stdlib.( == ) a__007_ b__008_
+     if a__007_ == b__008_
      then true
      else
-       Stdlib.( && )
-         (Platform.equal a__007_.platform b__008_.platform)
-         (Stdlib.( && )
-            (Protocol.equal a__007_.protocol b__008_.protocol)
-            (Stdlib.( && )
-               (User_handle.equal a__007_.user_handle b__008_.user_handle)
-               (Repo_name.equal a__007_.repo_name b__008_.repo_name)))
+       Platform.equal a__007_.platform b__008_.platform
+       && Protocol.equal a__007_.protocol b__008_.protocol
+       && User_handle.equal a__007_.user_handle b__008_.user_handle
+       && Repo_name.equal a__007_.repo_name b__008_.repo_name
    : t -> t -> bool)
 ;;
 
 [@@@coverage on]
 
-let seeded_hash = (Stdlib.Hashtbl.seeded_hash : int -> t -> int)
-let hash = (Stdlib.Hashtbl.hash : t -> int)
+let seeded_hash = (Hashtbl.seeded_hash : int -> t -> int)
+let hash = (Hashtbl.hash : t -> int)
 
 let to_string t =
   let { platform; protocol; user_handle; repo_name } = t in

--- a/lib/vcs/src/vcs.ml
+++ b/lib/vcs/src/vcs.ml
@@ -58,5 +58,8 @@ include Vcs0
 module Private = struct
   module Bit_vector = Bit_vector
   module Import = Import
+  module Int_table = Int_table
+  module Ref_kind_table = Ref_kind_table
+  module Rev_table = Rev_table
   module Validated_string = Validated_string
 end

--- a/lib/vcs/src/vcs.mli
+++ b/lib/vcs/src/vcs.mli
@@ -330,5 +330,8 @@ module Private : sig
 
   module Bit_vector = Bit_vector
   module Import = Import
+  module Int_table = Int_table
+  module Ref_kind_table = Ref_kind_table
+  module Rev_table = Rev_table
   module Validated_string = Validated_string
 end

--- a/lib/vcs/src/vcs_exn.ml
+++ b/lib/vcs/src/vcs_exn.ml
@@ -20,7 +20,7 @@
 (*******************************************************************************)
 
 let reraise_with_context err bt ~step =
-  Stdlib.Printexc.raise_with_backtrace (Exn0.E (Err.add_context err ~step)) bt
+  Printexc.raise_with_backtrace (Exn0.E (Err.add_context err ~step)) bt
 ;;
 
 module Private = struct

--- a/lib/vcs/src/vcs_exn.mli
+++ b/lib/vcs/src/vcs_exn.mli
@@ -43,13 +43,13 @@
             ~step:[%sexp "doing_something_with_arg", { arg : Arg.t }]
       ;;
     ]} *)
-val reraise_with_context : Err.t -> Stdlib.Printexc.raw_backtrace -> step:Sexp.t -> _
+val reraise_with_context : Err.t -> Printexc.raw_backtrace -> step:Sexp.t -> _
 
 module Private : sig
   (** [try_with f] runs [f] and wraps any exception it raises into an
       {!type:Err.t} error. Because this catches all exceptions, including
       exceptions that may not be designed to be caught (such as
-      [Stack_overlow], [Out_of_memory], etc.) we recommend that code be
+      [Stack_overflow], [Out_of_memory], etc.) we recommend that code be
       refactored overtime not to rely on this function. However, this is
       rather hard to do without assistance from the type checker, thus we
       currently rely on this function. TBD! *)

--- a/lib/vcs/src/vcs_rresult.ml
+++ b/lib/vcs/src/vcs_rresult.ml
@@ -27,7 +27,7 @@ type 'a result = 'a t
 
 include Non_raising.Make (Vcs_rresult0)
 
-let pp_error fmt (`Vcs err) = Stdlib.Format.pp_print_string fmt (Err.to_string_hum err)
+let pp_error fmt (`Vcs err) = Format.pp_print_string fmt (Err.to_string_hum err)
 
 let open_error = function
   | Ok _ as r -> r

--- a/lib/vcs/src/vcs_rresult.mli
+++ b/lib/vcs/src/vcs_rresult.mli
@@ -32,7 +32,7 @@ type 'a result = 'a t
     {{:https://erratique.ch/software/rresult/doc/Rresult/index.html#usage} Rresult}
     usage design guidelines. *)
 
-val pp_error : Stdlib.Format.formatter -> [ `Vcs of Err.t ] -> unit
+val pp_error : Format.formatter -> [ `Vcs of Err.t ] -> unit
 val open_error : 'a result -> ('a, [> `Vcs of Err.t ]) Result.t
 val error_to_msg : 'a result -> ('a, [ `Msg of string ]) Result.t
 

--- a/lib/vcs/test/test__import.ml
+++ b/lib/vcs/test/test__import.ml
@@ -1,0 +1,164 @@
+(*******************************************************************************)
+(*  Vcs - a Versatile OCaml Library for Git Operations                         *)
+(*  Copyright (C) 2024 Mathieu Barbin <mathieu.barbin@gmail.com>               *)
+(*                                                                             *)
+(*  This file is part of Vcs.                                                  *)
+(*                                                                             *)
+(*  Vcs is free software; you can redistribute it and/or modify it under       *)
+(*  the terms of the GNU Lesser General Public License as published by the     *)
+(*  Free Software Foundation either version 3 of the License, or any later     *)
+(*  version, with the LGPL-3.0 Linking Exception.                              *)
+(*                                                                             *)
+(*  Vcs is distributed in the hope that it will be useful, but WITHOUT ANY     *)
+(*  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS  *)
+(*  FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License and    *)
+(*  the file `NOTICE.md` at the root of this repository for more details.      *)
+(*                                                                             *)
+(*  You should have received a copy of the GNU Lesser General Public License   *)
+(*  and the LGPL-3.0 Linking Exception along with this library. If not, see    *)
+(*  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
+(*******************************************************************************)
+
+module Import = Vcs.Private.Import
+
+let%expect_test "Char.is_whitespace" =
+  let test c ~expect =
+    let is_whitespace = Import.Char.is_whitespace c in
+    print_s [%sexp { char = (c : char); is_whitespace : bool }];
+    require_equal [%here] (module Bool) is_whitespace expect
+  in
+  List.iter
+    ~f:(fun c -> test c ~expect:true)
+    [ ' '; '\t'; '\n'; '\011'; '\012'; '\r'; ' ' ];
+  [%expect
+    {|
+    ((char          " ")
+     (is_whitespace true))
+    ((char          "\t")
+     (is_whitespace true))
+    ((char          "\n")
+     (is_whitespace true))
+    ((char          "\011")
+     (is_whitespace true))
+    ((char          "\012")
+     (is_whitespace true))
+    ((char          "\r")
+     (is_whitespace true))
+    ((char          " ")
+     (is_whitespace true))
+    |}];
+  List.iter
+    ~f:(fun c -> test c ~expect:false)
+    [ 'a'; 'A'; '0'; '9'; 'z'; 'Z'; '1'; '8'; 'x'; 'X' ];
+  [%expect
+    {|
+    ((char          a)
+     (is_whitespace false))
+    ((char          A)
+     (is_whitespace false))
+    ((char          0)
+     (is_whitespace false))
+    ((char          9)
+     (is_whitespace false))
+    ((char          z)
+     (is_whitespace false))
+    ((char          Z)
+     (is_whitespace false))
+    ((char          1)
+     (is_whitespace false))
+    ((char          8)
+     (is_whitespace false))
+    ((char          x)
+     (is_whitespace false))
+    ((char          X)
+     (is_whitespace false))
+    |}];
+  ()
+;;
+
+let%expect_test "Int.to_string_hum" =
+  let test i = print_endline (Import.Int.to_string_hum i) in
+  List.iter
+    ~f:test
+    [ 0
+    ; 42
+    ; 421
+    ; 1_234
+    ; 12_345
+    ; 123_456
+    ; 1_234_567
+    ; 12_345_678
+    ; -3
+    ; -99
+    ; -123
+    ; -1_234
+    ; -12_345
+    ; -123_456
+    ; -1_234_567
+    ; -12_345_678
+    ];
+  [%expect
+    {|
+    0
+    42
+    421
+    1_234
+    12_345
+    123_456
+    1_234_567
+    12_345_678
+    -3
+    -99
+    -123
+    -1_234
+    -12_345
+    -123_456
+    -1_234_567
+    -12_345_678
+    |}];
+  ()
+;;
+
+let%expect_test "Int_table.add_exn" =
+  let module Int_table = Vcs.Private.Int_table in
+  let table = Int_table.create 3 in
+  Int_table.add_exn table ~key:1_234 ~data:"one";
+  require_does_raise [%here] (fun () ->
+    Int_table.add_exn table ~key:1_234 ~data:"one prime");
+  [%expect {| ("Hashtbl.add_exn: key already present" ((key 1_234))) |}];
+  ()
+;;
+
+let%expect_test "String.split_lines" =
+  let test s =
+    let lines = Import.String.split_lines s in
+    print_s [%sexp (lines : string list)]
+  in
+  test "";
+  [%expect {| () |}];
+  test "\n";
+  [%expect {| ("") |}];
+  test "Hello\r\nWorld";
+  [%expect {| (Hello World) |}];
+  test "Hello\nWorld";
+  [%expect {| (Hello World) |}];
+  test "Hello\r\nWorld\r\n";
+  [%expect {| (Hello World) |}];
+  test "Hello\nWorld\n";
+  [%expect {| (Hello World) |}];
+  test "Hello\nWorld\n\n";
+  [%expect {| (Hello World "") |}];
+  ()
+;;
+
+let%expect_test "equal_list" =
+  let test a b = Import.equal_list Int.equal a b in
+  let r = [ 1; 2; 3 ] in
+  require [%here] (test r r);
+  require [%here] (test [ 1; 2; 3 ] [ 1; 2; 3 ]);
+  require [%here] (test [] []);
+  require [%here] (not (test [ 1; 2; 3 ] [ 1; 2 ]));
+  require [%here] (not (test [ 1; 2; 3 ] [ 1; 2; 4 ]));
+  require [%here] (not (test [] [ 1 ]));
+  ()
+;;

--- a/lib/vcs/test/test__import.mli
+++ b/lib/vcs/test/test__import.mli
@@ -18,10 +18,3 @@
 (*_  and the LGPL-3.0 Linking Exception along with this library. If not, see    *)
 (*_  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*_******************************************************************************)
-
-type t = Vcs.Num_lines_in_diff.t =
-  { insertions : int
-  ; deletions : int
-  }
-
-include module type of Vcs.Num_lines_in_diff with type t := t

--- a/lib/vcs/test/test__mock_revs.ml
+++ b/lib/vcs/test/test__mock_revs.ml
@@ -45,8 +45,9 @@ let%expect_test "mock revs" =
     Vcs.Mock_revs.add_exn t ~rev:rev0 ~mock_rev:mock_rev1);
   [%expect
     {|
-    ("Hashtbl.add_exn got key already present"
-     dd5aabd331a75b90cd61725223964e47dd5aabd3) |}];
+    ("Hashtbl.add_exn: key already present" ((
+      key dd5aabd331a75b90cd61725223964e47dd5aabd3)))
+    |}];
   (* Finally, as a convenience we can generate mock revision on the fly with
      [to_mock]. *)
   let rev1 = Vcs.Mock_revs.next t in

--- a/lib/vcs/test/test__num_lines_in_diff.ml
+++ b/lib/vcs/test/test__num_lines_in_diff.ml
@@ -79,7 +79,7 @@ let%expect_test "to_string_hum" =
   test { insertions = 0; deletions = 15 };
   [%expect {| -15 |}];
   test { insertions = 1999; deletions = 13898 };
-  [%expect {| +1,999, -13,898 |}];
+  [%expect {| +1_999, -13_898 |}];
   ()
 ;;
 

--- a/lib/vcs_base/src/num_lines_in_diff.ml
+++ b/lib/vcs_base/src/num_lines_in_diff.ml
@@ -20,17 +20,3 @@
 (*******************************************************************************)
 
 include Vcs.Num_lines_in_diff
-
-let to_string_hum { insertions; deletions } =
-  let int_hum i = Int.to_string_hum ~delimiter:',' i in
-  match
-    [ (if insertions > 0 then Some ("+" ^ int_hum insertions) else None)
-    ; (if deletions > 0 then Some ("-" ^ int_hum deletions) else None)
-    ]
-    |> List.filter_opt
-  with
-  | [] -> "0"
-  | [ hd ] -> hd
-  | [ a; b ] -> a ^ ", " ^ b
-  | _ :: _ :: _ :: _ -> assert false
-;;

--- a/lib/vcs_base/test/test__num_lines_in_diff.ml
+++ b/lib/vcs_base/test/test__num_lines_in_diff.ml
@@ -30,6 +30,6 @@ let%expect_test "to_string_hum" =
   test { insertions = 0; deletions = 15 };
   [%expect {| -15 |}];
   test { insertions = 1999; deletions = 13898 };
-  [%expect {| +1,999, -13,898 |}];
+  [%expect {| +1_999, -13_898 |}];
   ()
 ;;

--- a/lib/vcs_command/src/dune
+++ b/lib/vcs_command/src/dune
@@ -8,12 +8,14 @@
   -warn-error
   +a
   -open
-  Base
-  -open
   Fpath_sexp0
   -open
-  Cmdlang)
- (libraries base cmdlang eio eio_main fpath-sexp0 vcs vcs-git-eio)
+  Cmdlang
+  -open
+  Sexplib0
+  -open
+  Sexplib0.Sexp_conv)
+ (libraries cmdlang eio eio_main fpath-sexp0 sexplib0 vcs vcs-git-eio)
  (instrumentation
   (backend bisect_ppx))
  (lint

--- a/lib/vcs_command/src/dune
+++ b/lib/vcs_command/src/dune
@@ -17,14 +17,6 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -check-doc-comments))
+  (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
-  (pps
-   -unused-code-warnings=force
-   ppx_compare
-   ppx_enumerate
-   ppx_hash
-   ppx_here
-   ppx_let
-   ppx_sexp_conv
-   ppx_sexp_value)))
+  (pps -unused-code-warnings=force ppx_sexp_conv ppx_sexp_value)))

--- a/lib/vcs_command/src/vcs_command.ml
+++ b/lib/vcs_command/src/vcs_command.ml
@@ -25,7 +25,7 @@ open! Import
    the name the associated function has in the [V.S] interface, prepending the
    suffix "_cmd". *)
 
-let print_sexp sexp = Stdlib.print_endline (Sexp.to_string_hum sexp)
+let print_sexp sexp = print_endline (Sexp.to_string_hum sexp)
 
 module Initialized = struct
   type t =
@@ -155,7 +155,7 @@ let find_enclosing_repo_root_cmd =
      match Vcs.find_enclosing_repo_root vcs ~from ~store with
      | None -> ()
      | Some (`Store store, repo_root) ->
-       Stdlib.Printf.printf
+       Printf.printf
          "%s: %s\n"
          (Fsegment.to_string store)
          (Vcs.Repo_root.to_string repo_root))
@@ -171,11 +171,11 @@ let git_cmd =
      @@ fun env ->
      let { Initialized.vcs; repo_root; cwd = _ } = initialize ~env in
      let { Vcs.Git.Output.exit_code; stdout; stderr } =
-       Vcs.git vcs ~repo_root ~args ~f:Fn.id
+       Vcs.git vcs ~repo_root ~args ~f:Fun.id
      in
-     Stdlib.print_string stdout;
-     Stdlib.prerr_string stderr;
-     if exit_code <> 0 then Stdlib.exit exit_code)
+     print_string stdout;
+     prerr_string stderr;
+     if exit_code <> 0 then exit exit_code)
 ;;
 
 let init_cmd =
@@ -214,7 +214,7 @@ let load_file_cmd =
      let { Initialized.vcs; repo_root = _; cwd } = initialize ~env in
      let path = Absolute_path.relativize ~root:cwd path in
      let contents = Vcs.load_file vcs ~path in
-     Stdlib.print_string (contents :> string);
+     print_string (contents :> string);
      ())
 ;;
 
@@ -237,8 +237,7 @@ let ls_files_cmd =
        | Some path -> relativize ~repo_root ~cwd ~path
      in
      let files = Vcs.ls_files vcs ~repo_root ~below in
-     List.iter files ~f:(fun file ->
-       Stdlib.print_endline (Vcs.Path_in_repo.to_string file));
+     List.iter files ~f:(fun file -> print_endline (Vcs.Path_in_repo.to_string file));
      ())
 ;;
 
@@ -421,9 +420,9 @@ let show_file_at_rev_cmd =
      let path = relativize ~repo_root ~cwd ~path in
      let result = Vcs.show_file_at_rev vcs ~repo_root ~rev ~path in
      (match result with
-      | `Present contents -> Stdlib.print_string (contents :> string)
+      | `Present contents -> print_string (contents :> string)
       | `Absent ->
-        Stdlib.Printf.eprintf
+        Printf.eprintf
           "Path '%s' does not exist in '%s'"
           (Vcs.Path_in_repo.to_string path)
           (Vcs.Rev.to_string rev));

--- a/lib/vcs_command/src/vcs_command.ml
+++ b/lib/vcs_command/src/vcs_command.ml
@@ -65,10 +65,12 @@ let relativize ~repo_root ~cwd ~path =
       (Vcs.E (Vcs.Err.create_s [%sexp "Path is not in repo", { path : Absolute_path.t }]))
 ;;
 
+open Command.Std
+
 let add_cmd =
   Command.make
     ~summary:"add a file to the index"
-    (let%map_open.Command path =
+    (let+ path =
        Arg.pos
          ~pos:0
          (Param.validated_string (module Fpath))
@@ -86,13 +88,13 @@ let add_cmd =
 let commit_cmd =
   Command.make
     ~summary:"commit a file"
-    (let%map_open.Command commit_message =
+    (let+ commit_message =
        Arg.named
          [ "message"; "m" ]
          (Param.validated_string (module Vcs.Commit_message))
          ~docv:"MSG"
          ~doc:"commit message"
-     and quiet = Arg.flag [ "quiet"; "q" ] ~doc:"suppress output on success" in
+     and+ quiet = Arg.flag [ "quiet"; "q" ] ~doc:"suppress output on success" in
      Eio_main.run
      @@ fun env ->
      let { Initialized.vcs; repo_root; cwd = _ } = initialize ~env in
@@ -104,7 +106,7 @@ let commit_cmd =
 let current_branch_cmd =
   Command.make
     ~summary:"current branch"
-    (let%map_open.Command () = Arg.return () in
+    (let+ () = Arg.return () in
      Eio_main.run
      @@ fun env ->
      let { Initialized.vcs; repo_root; cwd = _ } = initialize ~env in
@@ -116,7 +118,7 @@ let current_branch_cmd =
 let current_revision_cmd =
   Command.make
     ~summary:"revision of HEAD"
-    (let%map_open.Command () = Arg.return () in
+    (let+ () = Arg.return () in
      Eio_main.run
      @@ fun env ->
      let { Initialized.vcs; repo_root; cwd = _ } = initialize ~env in
@@ -128,13 +130,13 @@ let current_revision_cmd =
 let find_enclosing_repo_root_cmd =
   Command.make
     ~summary:"find enclosing repo root"
-    (let%map_open.Command from =
+    (let+ from =
        Arg.named_opt
          [ "from" ]
          (Param.validated_string (module Fpath))
          ~docv:"path/to/dir"
          ~doc:"walk up from the supplied directory (default is cwd)"
-     and store =
+     and+ store =
        Arg.named_opt
          [ "store" ]
          (Param.comma_separated (Param.validated_string (module Fsegment)))
@@ -162,7 +164,7 @@ let find_enclosing_repo_root_cmd =
 let git_cmd =
   Command.make
     ~summary:"run the git cli"
-    (let%map_open.Command args =
+    (let+ args =
        Arg.pos_all Param.string ~docv:"ARG" ~doc:"pass the remaining args to git"
      in
      Eio_main.run
@@ -179,13 +181,13 @@ let git_cmd =
 let init_cmd =
   Command.make
     ~summary:"initialize a new repository"
-    (let%map_open.Command path =
+    (let+ path =
        Arg.pos
          ~pos:0
          (Param.validated_string (module Fpath))
          ~docv:"path/to/root"
          ~doc:"where to initialize the repository"
-     and quiet =
+     and+ quiet =
        Arg.flag [ "quiet"; "q" ] ~doc:"do not print the initialized repo root"
      in
      Eio_main.run
@@ -200,7 +202,7 @@ let init_cmd =
 let load_file_cmd =
   Command.make
     ~summary:"print a file from the filesystem (aka cat)"
-    (let%map_open.Command path =
+    (let+ path =
        Arg.pos
          ~pos:0
          (Param.validated_string (module Fpath))
@@ -219,7 +221,7 @@ let load_file_cmd =
 let ls_files_cmd =
   Command.make
     ~summary:"list file"
-    (let%map_open.Command below =
+    (let+ below =
        Arg.named_opt
          [ "below" ]
          (Param.validated_string (module Fpath))
@@ -243,7 +245,7 @@ let ls_files_cmd =
 let log_cmd =
   Command.make
     ~summary:"show the log of current repo"
-    (let%map_open.Command () = Arg.return () in
+    (let+ () = Arg.return () in
      Eio_main.run
      @@ fun env ->
      let { Initialized.vcs; repo_root; cwd = _ } = initialize ~env in
@@ -255,13 +257,13 @@ let log_cmd =
 let name_status_cmd =
   Command.make
     ~summary:"show a summary of the diff between 2 revs"
-    (let%map_open.Command src =
+    (let+ src =
        Arg.pos
          ~pos:0
          (Param.validated_string (module Vcs.Rev))
          ~docv:"BASE"
          ~doc:"base revision"
-     and dst =
+     and+ dst =
        Arg.pos
          ~pos:1
          (Param.validated_string (module Vcs.Rev))
@@ -279,13 +281,13 @@ let name_status_cmd =
 let num_status_cmd =
   Command.make
     ~summary:"show a summary of the number of lines of diff between 2 revs"
-    (let%map_open.Command src =
+    (let+ src =
        Arg.pos
          ~pos:0
          (Param.validated_string (module Vcs.Rev))
          ~docv:"BASE"
          ~doc:"base revision"
-     and dst =
+     and+ dst =
        Arg.pos
          ~pos:1
          (Param.validated_string (module Vcs.Rev))
@@ -303,7 +305,7 @@ let num_status_cmd =
 let read_dir_cmd =
   Command.make
     ~summary:"print the list of files in a directory"
-    (let%map_open.Command dir =
+    (let+ dir =
        Arg.pos
          ~pos:0
          (Param.validated_string (module Fpath))
@@ -322,7 +324,7 @@ let read_dir_cmd =
 let rename_current_branch_cmd =
   Command.make
     ~summary:"move/rename a branch to a new name"
-    (let%map_open.Command branch_name =
+    (let+ branch_name =
        Arg.pos
          ~pos:0
          (Param.validated_string (module Vcs.Branch_name))
@@ -339,7 +341,7 @@ let rename_current_branch_cmd =
 let refs_cmd =
   Command.make
     ~summary:"show the refs of current repo"
-    (let%map_open.Command () = Arg.return () in
+    (let+ () = Arg.return () in
      Eio_main.run
      @@ fun env ->
      let { Initialized.vcs; repo_root; cwd = _ } = initialize ~env in
@@ -351,7 +353,7 @@ let refs_cmd =
 let save_file_cmd =
   Command.make
     ~summary:"save stdin to a file from the filesystem (aka tee)"
-    (let%map_open.Command path =
+    (let+ path =
        Arg.pos
          ~pos:0
          (Param.validated_string (module Fpath))
@@ -376,13 +378,13 @@ let save_file_cmd =
 let set_user_config_cmd =
   Command.make
     ~summary:"set the user config"
-    (let%map_open.Command user_name =
+    (let+ user_name =
        Arg.named
          [ "user.name" ]
          (Param.validated_string (module Vcs.User_name))
          ~docv:"USER"
          ~doc:"user name"
-     and user_email =
+     and+ user_email =
        Arg.named
          [ "user.email" ]
          (Param.validated_string (module Vcs.User_email))
@@ -400,13 +402,13 @@ let set_user_config_cmd =
 let show_file_at_rev_cmd =
   Command.make
     ~summary:"show the contents of file at a given revision"
-    (let%map_open.Command rev =
+    (let+ rev =
        Arg.named
          [ "rev"; "r" ]
          (Param.validated_string (module Vcs.Rev))
          ~docv:"REV"
          ~doc:"revision to show"
-     and path =
+     and+ path =
        Arg.pos
          ~pos:0
          (Param.validated_string (module Fpath))
@@ -431,7 +433,7 @@ let show_file_at_rev_cmd =
 let graph_cmd =
   Command.make
     ~summary:"compute graph of current repo"
-    (let%map_open.Command () = Arg.return () in
+    (let+ () = Arg.return () in
      Eio_main.run
      @@ fun env ->
      let { Initialized.vcs; repo_root; cwd = _ } = initialize ~env in
@@ -445,7 +447,7 @@ let graph_cmd =
 let branch_revision_cmd =
   Command.make
     ~summary:"revision of a branch"
-    (let%map_open.Command branch_name =
+    (let+ branch_name =
        Arg.pos_opt
          ~pos:0
          (Param.validated_string (module Vcs.Branch_name))
@@ -480,7 +482,7 @@ let branch_revision_cmd =
 let greatest_common_ancestors_cmd =
   Command.make
     ~summary:"print greatest common ancestors of revisions"
-    (let%map_open.Command revs =
+    (let+ revs =
        Arg.pos_all
          (Param.validated_string (module Vcs.Rev))
          ~docv:"REV"

--- a/lib/vcs_git_blocking/src/dune
+++ b/lib/vcs_git_blocking/src/dune
@@ -8,10 +8,12 @@
   -warn-error
   +a
   -open
-  Base
+  Fpath_sexp0
   -open
-  Fpath_sexp0)
- (libraries base fpath fpath-sexp0 provider unix vcs vcs-git-provider)
+  Sexplib0
+  -open
+  Sexplib0.Sexp_conv)
+ (libraries fpath fpath-sexp0 provider unix vcs vcs-git-provider)
  (instrumentation
   (backend bisect_ppx))
  (lint

--- a/lib/vcs_git_eio/src/dune
+++ b/lib/vcs_git_eio/src/dune
@@ -8,10 +8,12 @@
   -warn-error
   +a
   -open
-  Base
+  Fpath_sexp0
   -open
-  Fpath_sexp0)
- (libraries base eio fpath fpath-sexp0 vcs vcs-git-provider)
+  Sexplib0
+  -open
+  Sexplib0.Sexp_conv)
+ (libraries eio fpath fpath-sexp0 sexplib0 vcs vcs-git-provider)
  (instrumentation
   (backend bisect_ppx))
  (lint

--- a/lib/vcs_git_eio/src/runtime.ml
+++ b/lib/vcs_git_eio/src/runtime.ml
@@ -115,7 +115,7 @@ module Lines = struct
   let create string : t = String.split_lines string
 end
 
-exception Uncaught_user_exn of exn * Stdlib.Printexc.raw_backtrace
+exception Uncaught_user_exn of exn * Printexc.raw_backtrace
 
 let git ?env t ~cwd ~args ~f =
   let cwd = Eio.Path.(t.fs / Absolute_path.to_string cwd) in
@@ -153,7 +153,7 @@ let git ?env t ~cwd ~args ~f =
     exit_status_r := (exit_status :> [ Exit_status.t | `Unknown ]);
     match exit_status with
     | `Signaled signal ->
-      Stdlib.raise_notrace
+      raise_notrace
         (Vcs.E
            (Vcs.Err.create_s
               [%sexp "process exited abnormally", { signal : int }] [@coverage off]))
@@ -171,12 +171,12 @@ let git ?env t ~cwd ~args ~f =
       *)
       (match f { Vcs.Git.Output.exit_code; stdout; stderr } with
        | Ok _ as ok -> ok
-       | Error err -> Stdlib.raise_notrace (Vcs.E err) [@coverage off]
+       | Error err -> raise_notrace (Vcs.E err) [@coverage off]
        | exception exn ->
-         let bt = Stdlib.Printexc.get_raw_backtrace () in
-         (Stdlib.raise_notrace (Uncaught_user_exn (exn, bt)) [@coverage off]))
+         let bt = Printexc.get_raw_backtrace () in
+         (raise_notrace (Uncaught_user_exn (exn, bt)) [@coverage off]))
   with
-  | Uncaught_user_exn (exn, bt) -> Stdlib.Printexc.raise_with_backtrace exn bt
+  | Uncaught_user_exn (exn, bt) -> Printexc.raise_with_backtrace exn bt
   | exn ->
     let err =
       match exn with

--- a/lib/vcs_git_provider/src/dune
+++ b/lib/vcs_git_provider/src/dune
@@ -8,12 +8,12 @@
   -warn-error
   +a
   -open
-  Base
-  -open
   Fpath_sexp0
   -open
-  Or_error.Let_syntax)
- (libraries base fpath fpath-sexp0 vcs)
+  Sexplib0
+  -open
+  Sexplib0.Sexp_conv)
+ (libraries astring fpath fpath-sexp0 sexplib0 vcs)
  (instrumentation
   (backend bisect_ppx))
  (lint

--- a/lib/vcs_git_provider/src/log.ml
+++ b/lib/vcs_git_provider/src/log.ml
@@ -25,6 +25,7 @@ let parse_log_line_exn ~line:str : Vcs.Log.Line.t =
   match
     Vcs.Exn.Private.try_with (fun () ->
       match String.split (String.strip str) ~on:' ' with
+      | [] -> assert false (* [String.split] never returns the empty list. *)
       | [ rev ] -> Vcs.Log.Line.Root { rev = Vcs.Rev.v rev }
       | [ rev; parent ] -> Commit { rev = Vcs.Rev.v rev; parent = Vcs.Rev.v parent }
       | [ rev; parent1; parent2 ] ->
@@ -33,7 +34,6 @@ let parse_log_line_exn ~line:str : Vcs.Log.Line.t =
           ; parent1 = Vcs.Rev.v parent1
           ; parent2 = Vcs.Rev.v parent2
           }
-      | [] -> assert false
       | _ :: _ :: _ :: _ ->
         raise (Vcs.E (Vcs.Err.error_string "Too many words (expected 1, 2, or 3)")))
   with

--- a/lib/vcs_git_provider/src/munged_path.ml
+++ b/lib/vcs_git_provider/src/munged_path.ml
@@ -35,25 +35,37 @@ end
 
 include T
 
-let arrow = lazy (String.Search_pattern.create " => ")
-
 let parse_exn str =
   match
     Vcs.Exn.Private.try_with (fun () ->
-      match String.Search_pattern.split_on (force arrow) str with
-      | [ str ] -> One_file (Vcs.Path_in_repo.v str)
+      match Astring.String.cuts ~empty:false ~sep:" => " str with
+      | [] -> raise (Vcs.E (Vcs.Err.error_string "Unexpected empty path"))
+      | [ str ] ->
+        if String.exists str ~f:(function
+             | '{' | '}' -> true
+             | _ -> false)
+        then raise (Vcs.E (Vcs.Err.error_string "Unexpected '{' or '}' in simple path"))
+        else One_file (Vcs.Path_in_repo.v str)
       | [ left; right ] ->
         (match String.rsplit2 left ~on:'{' with
          | None ->
-           Two_files { src = Vcs.Path_in_repo.v left; dst = Vcs.Path_in_repo.v right }
+           if String.exists str ~f:(function
+                | '}' -> true
+                | _ -> false)
+           then raise (Vcs.E (Vcs.Err.error_string "Matching '{' not found"))
+           else
+             Two_files { src = Vcs.Path_in_repo.v left; dst = Vcs.Path_in_repo.v right }
          | Some (prefix, left_of_arrow) ->
-           let right_of_arrow, suffix = String.lsplit2_exn right ~on:'}' in
+           let right_of_arrow, suffix =
+             match String.lsplit2 right ~on:'}' with
+             | Some split -> split
+             | None -> raise (Vcs.E (Vcs.Err.error_string "Matching '}' not found"))
+           in
            Two_files
              { src = Vcs.Path_in_repo.v (prefix ^ left_of_arrow ^ suffix)
              ; dst = Vcs.Path_in_repo.v (prefix ^ right_of_arrow ^ suffix)
              })
-      | _ :: _ :: _ -> raise (Vcs.E (Vcs.Err.error_string "Too many '=>'"))
-      | [] -> assert false)
+      | _ :: _ :: _ -> raise (Vcs.E (Vcs.Err.error_string "Too many '=>'")))
   with
   | Ok t -> t
   | Error err ->

--- a/lib/vcs_git_provider/src/refs.mli
+++ b/lib/vcs_git_provider/src/refs.mli
@@ -34,6 +34,28 @@ end
 val parse_ref_kind_exn : string -> Vcs.Ref_kind.t
 
 module Dereferenced : sig
+  (** A [ref_kind] may appear several times in the lines, in which case it will
+      be present both dereferenced and non-dereferenced. Because we want to
+      retrieve the revisions each ref is pointed to, we only want to keep the
+      dereferenced occurrences.
+
+      We test for this case using the data from [super-master-mind.refs] which
+      contains the following lines:
+
+      {v
+        f4875717f6cd5481f690c88baad1fb1eff4e1a22 refs/tags/0.0.2
+        0d4750ff594236a4bd970e1c90b8bbad80fcadff refs/tags/0.0.2^{}
+        d5d13aaed2bd0c2f4a37217a21d703c73b8f38d6 refs/tags/0.0.3
+        fc8e67fbc47302b7da682e9a7da626790bb59eaa refs/tags/0.0.3^{}
+      v}
+
+      In this input, [0.0.2] and [0.0.3] are non-dereferenced items. The sha
+      associated with them are identifiers for the tag objects, rather than the
+      commit revisions they point to.
+
+      The dereferenced items are [0.0.2^{}] and [0.0.3^{}], and their sha are
+      the commit revisions. *)
+
   type t =
     { rev : Vcs.Rev.t
     ; ref_kind : Vcs.Ref_kind.t

--- a/lib/vcs_git_provider/test/test__munged_path.ml
+++ b/lib/vcs_git_provider/test/test__munged_path.ml
@@ -28,7 +28,7 @@ let%expect_test "parse" =
     {|
     (Vcs.E (
       (steps ((Vcs_git_provider.Munged_path.parse_exn ((path "")))))
-      (error (Invalid_argument "\"\": invalid path"))))
+      (error "Unexpected empty path")))
     |}];
   require_does_raise [%here] (fun () -> test "/tmp => /tmp");
   [%expect
@@ -44,6 +44,34 @@ let%expect_test "parse" =
       (steps ((
         Vcs_git_provider.Munged_path.parse_exn ((path "tmp => tmp2 => tmp3")))))
       (error "Too many '=>'")))
+    |}];
+  require_does_raise [%here] (fun () -> test "}");
+  [%expect
+    {|
+    (Vcs.E (
+      (steps ((Vcs_git_provider.Munged_path.parse_exn ((path })))))
+      (error "Unexpected '{' or '}' in simple path")))
+    |}];
+  require_does_raise [%here] (fun () -> test "{");
+  [%expect
+    {|
+    (Vcs.E (
+      (steps ((Vcs_git_provider.Munged_path.parse_exn ((path {)))))
+      (error "Unexpected '{' or '}' in simple path")))
+    |}];
+  require_does_raise [%here] (fun () -> test "a/{dir => b");
+  [%expect
+    {|
+    (Vcs.E (
+      (steps ((Vcs_git_provider.Munged_path.parse_exn ((path "a/{dir => b")))))
+      (error "Matching '}' not found")))
+    |}];
+  require_does_raise [%here] (fun () -> test "a/dir => b}");
+  [%expect
+    {|
+    (Vcs.E (
+      (steps ((Vcs_git_provider.Munged_path.parse_exn ((path "a/dir => b}")))))
+      (error "Matching '{' not found")))
     |}];
   test "a/simple/path";
   [%expect {| (One_file a/simple/path) |}];

--- a/lib/vcs_git_provider/test/test__refs.ml
+++ b/lib/vcs_git_provider/test/test__refs.ml
@@ -62,7 +62,7 @@ let%expect_test "parse_ref_kind_exn" =
     {|
     (Vcs.E (
       (steps ((Vcs_git_provider.Refs.parse_ref_kind_exn ((ref_kind blah)))))
-      (error (Invalid_argument "String.chop_prefix_exn \"blah\" \"refs/\""))))
+      (error "Expected ref to start with 'refs/'")))
     |}];
   require_does_raise [%here] (fun () -> test_ref_kind "non-refs/tags/0.0.1");
   [%expect
@@ -70,9 +70,7 @@ let%expect_test "parse_ref_kind_exn" =
     (Vcs.E (
       (steps ((
         Vcs_git_provider.Refs.parse_ref_kind_exn ((ref_kind non-refs/tags/0.0.1)))))
-      (error (
-        Invalid_argument
-        "String.chop_prefix_exn \"non-refs/tags/0.0.1\" \"refs/\""))))
+      (error "Expected ref to start with 'refs/'")))
     |}];
   test_ref_kind "refs/blah";
   [%expect {| (Other (name blah)) |}];

--- a/vcs-command.opam
+++ b/vcs-command.opam
@@ -10,7 +10,6 @@ bug-reports: "https://github.com/mbarbin/vcs/issues"
 depends: [
   "dune" {>= "3.16"}
   "ocaml" {>= "5.2"}
-  "base" {>= "v0.17" & < "v0.18"}
   "cmdlang" {>= "0.0.5"}
   "cmdlang-cmdliner-runner" {>= "0.0.5"}
   "cmdliner" {= "1.3.0"}
@@ -22,6 +21,7 @@ depends: [
   "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
   "ppxlib" {>= "0.33"}
+  "sexplib0" {>= "v0.17" & < "v0.18"}
   "vcs" {= version}
   "vcs-git-eio" {= version}
   "odoc" {with-doc}

--- a/vcs-command.opam
+++ b/vcs-command.opam
@@ -19,11 +19,6 @@ depends: [
   "err" {>= "0.0.5"}
   "fpath" {>= "0.7.3"}
   "fpath-sexp0" {>= "0.2.2"}
-  "ppx_compare" {>= "v0.17" & < "v0.18"}
-  "ppx_enumerate" {>= "v0.17" & < "v0.18"}
-  "ppx_hash" {>= "v0.17" & < "v0.18"}
-  "ppx_here" {>= "v0.17" & < "v0.18"}
-  "ppx_let" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
   "ppxlib" {>= "0.33"}

--- a/vcs-git-blocking.opam
+++ b/vcs-git-blocking.opam
@@ -14,11 +14,6 @@ depends: [
   "base" {>= "v0.17" & < "v0.18"}
   "fpath" {>= "0.7.3"}
   "fpath-sexp0" {>= "0.2.2"}
-  "ppx_compare" {>= "v0.17" & < "v0.18"}
-  "ppx_enumerate" {>= "v0.17" & < "v0.18"}
-  "ppx_hash" {>= "v0.17" & < "v0.18"}
-  "ppx_here" {>= "v0.17" & < "v0.18"}
-  "ppx_let" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
   "ppxlib" {>= "0.33"}

--- a/vcs-git-blocking.opam
+++ b/vcs-git-blocking.opam
@@ -11,13 +11,13 @@ bug-reports: "https://github.com/mbarbin/vcs/issues"
 depends: [
   "dune" {>= "3.16"}
   "ocaml" {>= "5.2"}
-  "base" {>= "v0.17" & < "v0.18"}
   "fpath" {>= "0.7.3"}
   "fpath-sexp0" {>= "0.2.2"}
   "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
   "ppxlib" {>= "0.33"}
   "provider" {>= "0.0.8"}
+  "sexplib0" {>= "v0.17" & < "v0.18"}
   "vcs" {= version}
   "vcs-git-provider" {= version}
   "odoc" {with-doc}

--- a/vcs-git-eio.opam
+++ b/vcs-git-eio.opam
@@ -14,11 +14,6 @@ depends: [
   "eio" {>= "1.0"}
   "fpath" {>= "0.7.3"}
   "fpath-sexp0" {>= "0.2.2"}
-  "ppx_compare" {>= "v0.17" & < "v0.18"}
-  "ppx_enumerate" {>= "v0.17" & < "v0.18"}
-  "ppx_hash" {>= "v0.17" & < "v0.18"}
-  "ppx_here" {>= "v0.17" & < "v0.18"}
-  "ppx_let" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
   "ppxlib" {>= "0.33"}

--- a/vcs-git-eio.opam
+++ b/vcs-git-eio.opam
@@ -10,7 +10,6 @@ bug-reports: "https://github.com/mbarbin/vcs/issues"
 depends: [
   "dune" {>= "3.16"}
   "ocaml" {>= "5.2"}
-  "base" {>= "v0.17" & < "v0.18"}
   "eio" {>= "1.0"}
   "fpath" {>= "0.7.3"}
   "fpath-sexp0" {>= "0.2.2"}
@@ -18,6 +17,7 @@ depends: [
   "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
   "ppxlib" {>= "0.33"}
   "provider" {>= "0.0.8"}
+  "sexplib0" {>= "v0.17" & < "v0.18"}
   "vcs" {= version}
   "vcs-git-provider" {= version}
   "odoc" {with-doc}

--- a/vcs-git-provider.opam
+++ b/vcs-git-provider.opam
@@ -10,12 +10,13 @@ bug-reports: "https://github.com/mbarbin/vcs/issues"
 depends: [
   "dune" {>= "3.16"}
   "ocaml" {>= "5.2"}
-  "base" {>= "v0.17" & < "v0.18"}
+  "astring" {>= "0.8.5"}
   "fpath" {>= "0.7.3"}
   "fpath-sexp0" {>= "0.2.2"}
   "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
   "ppxlib" {>= "0.33"}
+  "sexplib0" {>= "v0.17" & < "v0.18"}
   "vcs" {= version}
   "odoc" {with-doc}
 ]

--- a/vcs-git-provider.opam
+++ b/vcs-git-provider.opam
@@ -13,11 +13,6 @@ depends: [
   "base" {>= "v0.17" & < "v0.18"}
   "fpath" {>= "0.7.3"}
   "fpath-sexp0" {>= "0.2.2"}
-  "ppx_compare" {>= "v0.17" & < "v0.18"}
-  "ppx_enumerate" {>= "v0.17" & < "v0.18"}
-  "ppx_hash" {>= "v0.17" & < "v0.18"}
-  "ppx_here" {>= "v0.17" & < "v0.18"}
-  "ppx_let" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
   "ppxlib" {>= "0.33"}

--- a/vcs.opam
+++ b/vcs.opam
@@ -12,12 +12,8 @@ depends: [
   "ocaml" {>= "5.2"}
   "base" {>= "v0.17" & < "v0.18"}
   "fpath" {>= "0.7.3"}
-  "fpath-base" {>= "0.2.2"}
-  "ppx_compare" {>= "v0.17" & < "v0.18"}
+  "fpath-sexp0" {>= "0.2.2"}
   "ppx_enumerate" {>= "v0.17" & < "v0.18"}
-  "ppx_hash" {>= "v0.17" & < "v0.18"}
-  "ppx_here" {>= "v0.17" & < "v0.18"}
-  "ppx_let" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
   "ppxlib" {>= "0.33"}

--- a/vcs.opam
+++ b/vcs.opam
@@ -10,7 +10,6 @@ bug-reports: "https://github.com/mbarbin/vcs/issues"
 depends: [
   "dune" {>= "3.16"}
   "ocaml" {>= "5.2"}
-  "base" {>= "v0.17" & < "v0.18"}
   "fpath" {>= "0.7.3"}
   "fpath-sexp0" {>= "0.2.2"}
   "ppx_enumerate" {>= "v0.17" & < "v0.18"}


### PR DESCRIPTION
This PR implements Vcs_base stage 5 refactor as per `TODO.md` - Remove base dependency from `Vcs`.

### Changed

- Remove `base` dependency from `vcs` and provider libraries.
    - [x] vcs
    - [x] vcs_command
    - [x] vcs_git_blocking
    - [x] vcs_git_eio
    - [x] vcs_git_provider
