### PR TITLE
Prepare for 0.0.9

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## 0.0.9 (unreleased)
+## 0.0.9 (2024-10-23)
 
 ### Added
 
@@ -16,10 +16,9 @@
 - Rename what was `Vcs.Result` to `Vcs.Rresult` and introduce `Vcs.Result` whose type is simpler (#33, @mbarbin).
 - Moved `ocaml-vcs more-tests` commands at top-level (#28, @mbarbin).
 
-### Deprecated
-
 ### Fixed
 
+- Fixed stale refs information leaked by `Vcs.Graph.set_ref` (#40, @mbarbin).
 - Fixed some odoc warnings related to `Vcs_base` (#38, @mbarbin).
 - Changed some exceptions raised by the `vcs` related libraries to the `Vcs.E` exception (#34, @mbarbin).
 

--- a/doc/blog/2024-07-24-hello/index.md
+++ b/doc/blog/2024-07-24-hello/index.md
@@ -6,3 +6,5 @@ tags: [hello]
 ---
 
 Hello! I've just launched a blog section within the ocaml-vcs documentation, powered by Docusaurus. This new space is designed to keep you updated with all things related to ocaml-vcs. Stay tuned for more updates and insights. Happy reading!
+
+<!-- truncate -->

--- a/dune-project
+++ b/dune-project
@@ -340,6 +340,8 @@
     (< v0.18)))
   (vcs
    (= :version))
+  (vcs-base
+   (= :version))
   (vcs-command
    (= :version))
   (vcs-git-blocking

--- a/example/hello_blocking.ml
+++ b/example/hello_blocking.ml
@@ -36,7 +36,7 @@ let%expect_test "hello commit" =
     let path = Stdlib.Filename.temp_dir ~temp_dir:(Unix.getcwd ()) "vcs" "test" in
     Vcs_test_helpers.init vcs ~path:(Absolute_path.v path)
   in
-  (* Ok, we are all set, we are now inside a Git repo and we can start using
+  (* Ok, we are all set, [repo_root] points to a Git repo and we can start using
      [Vcs]. What we do in this example is simply create a new file and commit it
      to the repository, and query it from the store afterwards. *)
   let hello_file = Vcs.Path_in_repo.v "hello.txt" in

--- a/example/hello_error.ml
+++ b/example/hello_error.ml
@@ -20,7 +20,7 @@
 (*******************************************************************************)
 
 (* In this test we run a function from the Vcs API, let it raise an exception
-   and show out to catch it. This allows for a basic coverage of the raising
+   and show how to catch it. This allows for a basic coverage of the raising
    case of the API too. *)
 
 let%expect_test "hello error" =

--- a/lib/vcs/src/err.mli
+++ b/lib/vcs/src/err.mli
@@ -21,20 +21,23 @@
 
 (** The type of errors raised by [Vcs].
 
-    Under the hood, it is lazily constructed human-readable information which
-    also carry some context (a sort of a high level stack trace manipulated by
-    the programmers of Vcs).
+    Under the hood, it is human-readable information which also carries some
+    context (a sort of a high level stack trace manipulated by the programmers
+    of Vcs).
 
     It is not meant to be matched on, but rather to be printed on stderr (or
     perhaps logged). *)
 type t
 
-(** [sexp_of_t t] forces the lazy message, and allow printing the information
-    contained by [t]. *)
+(** {1 Printing} *)
+
+(** [sexp_of_t t] allows printing the information contained by [t]. *)
 val sexp_of_t : t -> Sexp.t
 
 (** [to_string_hum t] is a convenience wrapper around [t |> sexp_of_t |> Sexp.to_string_hum]. *)
 val to_string_hum : t -> string
+
+(** {1 Building} *)
 
 val error_string : string -> t
 val create_s : Sexp.t -> t

--- a/lib/vcs/src/git.mli
+++ b/lib/vcs/src/git.mli
@@ -19,8 +19,8 @@
 (*_  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*_******************************************************************************)
 
-(** Manipulating the output of process run by vcs and providers - typically the
-    ["git"] command. *)
+(** Manipulating the output of processes run by vcs and providers - typically
+    the ["git"] command. *)
 
 module Output : sig
   type t = Git_output0.t =

--- a/lib/vcs/src/graph.mli
+++ b/lib/vcs/src/graph.mli
@@ -49,8 +49,8 @@ val create : unit -> t
     simply operations that needs to be called to feed to [t] the information
     that already exists in the git log. *)
 
-(** [add t ~log] add to [t] all the nodes from the log. This is idempotent
-    this doesn't add the nodes that if [t] already knows.*)
+(** [add t ~log] add to [t] all the nodes from the log. This is idempotent -
+    this doesn't add the nodes that [t] already knows. *)
 val add_nodes : t -> log:Log.t -> unit
 
 (** [set_refs t ~refs] add to [t] all the refs from the log. *)
@@ -119,8 +119,8 @@ val prepend_parents : t -> node:Node.t -> prepend_to:Node.t list -> Node.t list
 val node_kind : t -> node:Node.t -> Node_kind.t
 
 (** If the graph has refs (such as tags or branches) attached to this node, they
-    will all be returned by [node_refs graph ~node]. The order of the refs in
-    the resulting list is not specified. *)
+    will all be returned by [node_refs graph ~node]. The refs are returned
+    ordered increasingly according to [Ref_kind.compare]. *)
 val node_refs : t -> node:Node.t -> Ref_kind.t list
 
 (** Return the number of nodes the graph currently holds. *)
@@ -128,7 +128,7 @@ val node_count : t -> int
 
 (** {1 Refs} *)
 
-(** List known refs. *)
+(** List known refs, ordered increasingly according to [Ref_kind.compare]. *)
 val refs : t -> Refs.t
 
 (** Find a ref if it is present. *)
@@ -143,7 +143,7 @@ val find_rev : t -> rev:Rev.t -> Node.t option
     [find_rev graph ~rev = Some _]. *)
 val mem_rev : t -> rev:Rev.t -> bool
 
-(** {1 Roots & Tips} *)
+(** {1 Roots & Leaves} *)
 
 (** Return the list of nodes that do not have any parents. *)
 val roots : t -> Node.t list
@@ -175,12 +175,12 @@ val is_ancestor_or_equal : t -> ancestor:Node.t -> descendant:Node.t -> bool
     of all the nodes in the set and is not a strict ancestor of any other common
     ancestor of the nodes.
 
-    If the nodes in [nodes] are unrelated, the function returns an empty list. If
-    there are multiple greatest common ancestors, all of them are included in
-    the returned list.
+    If the nodes in [nodes] do not have common ancestors, the function returns
+    an empty list. If there are multiple greatest common ancestors, all of them
+    are included in the returned list.
 
-    Multiple nodes may have multiple greatest common ancestors, especially in
-    cases of complex merge histories, hence the list return type. *)
+    A set of nodes may have multiple greatest common ancestors, especially in
+    cases of complex merge histories, hence the list returned type. *)
 val greatest_common_ancestors : t -> nodes:Node.t list -> Node.t list
 
 module Descendance : sig

--- a/lib/vcs/test/test__graph.ml
+++ b/lib/vcs/test/test__graph.ml
@@ -739,17 +739,9 @@ let%expect_test "debug graph" =
     print_s [%sexp (Vcs.Graph.node_refs graph ~node:(node ~rev) : Vcs.Ref_kind.t list)]
   in
   (* There are no longer any refs pointing to [r1]. *)
-  (* CR mbarbin: This shows the issue - see how the information attached to [r1] is stale. *)
   show_refs r1;
-  [%expect
-    {|
-    ((
-      Remote_branch (
-        remote_branch_name (
-          (remote_name origin)
-          (branch_name main)))))
-    |}];
-  (* Both [main] and [origin/main] points to [r4]. *)
+  [%expect {| () |}];
+  (* Both [main] and [origin/main] now point to [r4]. *)
   show_refs r4;
   [%expect
     {|
@@ -774,8 +766,6 @@ let%expect_test "debug graph" =
      ((rev 7216231cd107946841cc3eebe5da287b7216231c)
       (ref_kind (Tag (tag_name 0.1.0)))))
     |}];
-  (* CR mbarbin: This shows the issue also - see how the information attached
-     to [r1] in the field [refs] is stale. *)
   print_s [%sexp (graph : Vcs.Graph.t)];
   [%expect
     {|
@@ -804,19 +794,14 @@ let%expect_test "debug graph" =
        (#2 5deb4aaec51a75ef58765038b7c20b3f5deb4aae)
        (#1 f453b802f640c6888df978c712057d17f453b802)
        (#0 5cd237e9598b11065c344d1eb33bc8c15cd237e9)))
-     (refs (
-       (#4 (
+     (refs ((
+       #4 (
          (Local_branch (branch_name main))
          (Remote_branch (
            remote_branch_name (
              (remote_name origin)
              (branch_name main))))
-         (Tag (tag_name 0.1.0))))
-       (#1 ((
-         Remote_branch (
-           remote_branch_name (
-             (remote_name origin)
-             (branch_name main)))))))))
+         (Tag (tag_name 0.1.0)))))))
     |}];
   ()
 ;;

--- a/lib/vcs/test/test__graph.ml
+++ b/lib/vcs/test/test__graph.ml
@@ -590,15 +590,15 @@ let%expect_test "debug graph" =
     Vcs.Graph.add_nodes graph ~log:[ Vcs.Log.Line.Merge { rev; parent1; parent2 } ];
     rev
   in
-  let r1 = root () in
-  let r2 = commit ~parent:r1 in
-  let r3 = commit ~parent:r1 in
-  let m1 = merge ~parent1:r2 ~parent2:r3 in
+  let r0 = root () in
+  let r1 = commit ~parent:r0 in
+  let r2 = commit ~parent:r0 in
+  let m1 = merge ~parent1:r1 ~parent2:r2 in
   let r4 = commit ~parent:m1 in
   Vcs.Graph.set_refs
     graph
     ~refs:
-      [ { rev = r2
+      [ { rev = r1
         ; ref_kind =
             Remote_branch { remote_branch_name = Vcs.Remote_branch_name.v "origin/main" }
         }
@@ -651,9 +651,9 @@ let%expect_test "debug graph" =
     let node = node ~rev in
     print_s [%sexp (Vcs.Graph.node_kind graph ~node : Vcs.Graph.Node_kind.t)]
   in
-  node_kind r1;
+  node_kind r0;
   [%expect {| (Root (rev 5cd237e9598b11065c344d1eb33bc8c15cd237e9)) |}];
-  node_kind r2;
+  node_kind r1;
   [%expect
     {|
     (Commit
@@ -679,11 +679,11 @@ let%expect_test "debug graph" =
   let print_ancestors rev =
     print_s [%sexp (ancestors graph (node ~rev) : Set.M(Vcs.Graph.Node).t)]
   in
-  print_ancestors r1;
+  print_ancestors r0;
   [%expect {| (#0) |}];
-  print_ancestors r2;
+  print_ancestors r1;
   [%expect {| (#0 #1) |}];
-  print_ancestors r3;
+  print_ancestors r2;
   [%expect {| (#0 #2) |}];
   print_ancestors m1;
   [%expect {| (#0 #1 #2 #3) |}];
@@ -691,7 +691,7 @@ let%expect_test "debug graph" =
   [%expect {| (#0 #1 #2 #3 #4) |}];
   (* Low level int indexing. *)
   let node_index node = print_s [%sexp (Vcs.Graph.node_index node : int)] in
-  node_index (node ~rev:r1);
+  node_index (node ~rev:r0);
   [%expect {| 0 |}];
   node_index (node ~rev:r4);
   [%expect {| 4 |}];

--- a/lib/vcs/test/test__graph.ml
+++ b/lib/vcs/test/test__graph.ml
@@ -803,5 +803,20 @@ let%expect_test "debug graph" =
              (branch_name main))))
          (Tag (tag_name 0.1.0)))))))
     |}];
+  (* We also test a case where [set_ref] leaves at least one ref at the previous
+     location. *)
+  let custom_A = Vcs.Ref_kind.Other { name = "custom-A" } in
+  Vcs.Graph.set_ref graph ~rev:r0 ~ref_kind:custom_A;
+  Vcs.Graph.set_ref graph ~rev:r0 ~ref_kind:(Other { name = "custom-B" });
+  show_refs r0;
+  [%expect {|
+    ((Other (name custom-A))
+     (Other (name custom-B)))
+    |}];
+  Vcs.Graph.set_ref graph ~rev:r1 ~ref_kind:custom_A;
+  show_refs r0;
+  [%expect {| ((Other (name custom-B))) |}];
+  show_refs r1;
+  [%expect {| ((Other (name custom-A))) |}];
   ()
 ;;

--- a/lib/vcs_base/src/vcs_base.mli
+++ b/lib/vcs_base/src/vcs_base.mli
@@ -19,6 +19,46 @@
 (*_  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*_******************************************************************************)
 
+(** An extension of the Vcs library for use with Base.
+
+    [Vcs_base] is a library that extends the [Vcs] library with additional
+    modules and functionalities, aimed to improve the compatibility of [Vcs] for
+    programs using [Base].
+
+    For example, it adds [Comparable.S] to all container keys modules so that
+    they can be used with Base-style containers:
+
+    {[
+      let create_path_in_repo_table () = Hashtbl.create (module Vcs.Path_in_repo)
+    ]}
+
+    There's also a new module [Vcs.Or_error] which allows using [Vcs] with the
+    [Or_error] monad.
+
+    The library is designed to be used as a drop-in replacement for [Vcs]. For
+    this, it includes a single module named [Vcs] which must be setup to shadow
+    the regular [Vcs] module.
+
+    You may do so by defining the following module alias in a place that's
+    available to your scope:
+
+    {[
+      module Vcs = Vcs_base.Vcs
+    ]}
+
+    Another way to achieve this is to open [Vcs_base] via dune flags. When doing
+    that, all the files in your library will use [Vcs_base.Vcs] consistently.
+
+    {v
+      (library
+        (name my_library)
+        (flags (:standard -open Vcs_base))
+        (libraries vcs-base))
+    v}
+
+    This pattern is Vcs's authors favorite way of using [Vcs_base] and is the
+    way we're setting up [Vcs_base] in the examples of the Vcs repository. *)
+
 module Vcs : sig
   (** {1 Extended Vcs API} *)
 

--- a/test/data/README.md
+++ b/test/data/README.md
@@ -4,11 +4,9 @@ This directory contains some files that are used by tests.
 
 ## Repos source
 
-Data files are the result of git commands run inside a clone of different repos,
-keeping the repo name as basename for the files.
+Data files are the result of git commands run inside a clone of different repos, keeping the repo name as basename for the files.
 
-The repos were chosen somewhat arbitrarily, or given as part of a bug report,
-etc. We can add more files from other repos as needed.
+The repos were chosen somewhat arbitrarily, or given as part of a bug report, etc. We can add more files from other repos as needed.
 
 - [super-master-mind](https://github.com/mbarbin/super-master-mind)
 - [eio](https://github.com/ocaml-multicore/eio.git)

--- a/test/expect/find_ref.ml
+++ b/test/expect/find_ref.ml
@@ -151,8 +151,8 @@ let%expect_test "find ref" =
      is ambiguous, and we do not want to rely on the actual choice that it
      makes.
 
-     This is the reason why we ended up removing [rev_parse] from the vcs api, and replaced it
-     with the 2 technics shown above:
+     This is the reason why we ended up removing [rev_parse] from the vcs api,
+     and replaced it with the 2 technics shown above:
 
      1. [Vcs.Graph.find_ref] and
      2. [Vcs.refs |> Vcs.Refs.to_map]. *)

--- a/vcs-tests.opam
+++ b/vcs-tests.opam
@@ -43,6 +43,7 @@ depends: [
   "sexp_pretty" {>= "v0.17" & < "v0.18"}
   "stdio" {>= "v0.17" & < "v0.18"}
   "vcs" {= version}
+  "vcs-base" {= version}
   "vcs-command" {= version}
   "vcs-git-blocking" {= version}
   "vcs-git-eio" {= version}


### PR DESCRIPTION
### Changed

- Comments and formatting

### Fixed

- Fixed stale refs information leaked by `Vcs.Graph.set_ref` (Fixes #39)