### PR TITLE
Abstract traits constructors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,12 @@
 name: ci
 
 on:
-  - pull_request
-  - push
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "**" # This will match pull requests targeting any branch
 
 jobs:
   build:
@@ -27,8 +31,8 @@ jobs:
           opam-repositories: |
             default: https://github.com/ocaml/opam-repository.git
             mbarbin: https://github.com/mbarbin/opam-repository.git
-#           janestreet-bleeding: https://github.com/janestreet/opam-repository.git
-#           janestreet-bleeding-external: https://github.com/janestreet/opam-repository.git#external-packages
+      #     janestreet-bleeding: https://github.com/janestreet/opam-repository.git
+      #     janestreet-bleeding-external: https://github.com/janestreet/opam-repository.git#external-packages
 
       - name: Install dependencies
         run: opam install . --deps-only --with-doc --with-test --with-dev-setup
@@ -38,8 +42,8 @@ jobs:
 
       - name: Run tests
         run: |
-             mkdir $BISECT_DIR
-             opam exec -- dune runtest --instrument-with bisect_ppx
+          mkdir $BISECT_DIR
+          opam exec -- dune runtest --instrument-with bisect_ppx
         env:
           BISECT_DIR: ${{ runner.temp }}/_bisect_ppx_data
           BISECT_FILE: ${{ runner.temp }}/_bisect_ppx_data/data

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,17 @@
+## 0.0.10 (unreleased)
+
+### Added
+
+### Changed
+
+- Abstract the trait type constructors (PR, @mbarbin).
+
+### Deprecated
+
+### Fixed
+
+### Removed
+
 ## 0.0.9 (2024-10-23)
 
 ### Added

--- a/dune-project
+++ b/dune-project
@@ -104,7 +104,7 @@
   (cmdlang-cmdliner-runner
    (>= 0.0.5))
   (cmdliner
-   (= 1.3.0))
+   (>= 1.3.0))
   (eio
    (>= 1.0))
   (eio_main
@@ -258,7 +258,7 @@
   (cmdlang-to-cmdliner
    (>= 0.0.5))
   (cmdliner
-   (= 1.3.0))
+   (>= 1.3.0))
   (core
    (and
     (>= v0.17)

--- a/lib/vcs/src/trait.ml
+++ b/lib/vcs/src/trait.ml
@@ -24,6 +24,11 @@ and add_ty
 
 module Add = struct
   module type S = Trait_add.S
+
+  type (_, _, _) Provider.Trait.t +=
+    | Add : ('t, (module S with type t = 't), [> add ]) Provider.Trait.t
+
+  let t = Add
 end
 
 type branch = [ `Branch of branch_ty ]
@@ -31,6 +36,11 @@ and branch_ty
 
 module Branch = struct
   module type S = Trait_branch.S
+
+  type (_, _, _) Provider.Trait.t +=
+    | Branch : ('t, (module S with type t = 't), [> branch ]) Provider.Trait.t
+
+  let t = Branch
 end
 
 type commit = [ `Commit of commit_ty ]
@@ -38,6 +48,11 @@ and commit_ty
 
 module Commit = struct
   module type S = Trait_commit.S
+
+  type (_, _, _) Provider.Trait.t +=
+    | Commit : ('t, (module S with type t = 't), [> commit ]) Provider.Trait.t
+
+  let t = Commit
 end
 
 type config = [ `Config of config_ty ]
@@ -45,6 +60,11 @@ and config_ty
 
 module Config = struct
   module type S = Trait_config.S
+
+  type (_, _, _) Provider.Trait.t +=
+    | Config : ('t, (module S with type t = 't), [> config ]) Provider.Trait.t
+
+  let t = Config
 end
 
 type file_system = [ `File_system of file_system_ty ]
@@ -52,6 +72,11 @@ and file_system_ty
 
 module File_system = struct
   module type S = Trait_file_system.S
+
+  type (_, _, _) Provider.Trait.t +=
+    | File_system : ('t, (module S with type t = 't), [> file_system ]) Provider.Trait.t
+
+  let t = File_system
 end
 
 type git = [ `Git of git_ty ]
@@ -59,6 +84,11 @@ and git_ty
 
 module Git = struct
   module type S = Trait_git.S
+
+  type (_, _, _) Provider.Trait.t +=
+    | Git : ('t, (module S with type t = 't), [> git ]) Provider.Trait.t
+
+  let t = Git
 end
 
 type init = [ `Init of init_ty ]
@@ -66,6 +96,11 @@ and init_ty
 
 module Init = struct
   module type S = Trait_init.S
+
+  type (_, _, _) Provider.Trait.t +=
+    | Init : ('t, (module S with type t = 't), [> init ]) Provider.Trait.t
+
+  let t = Init
 end
 
 type log = [ `Log of log_ty ]
@@ -73,6 +108,11 @@ and log_ty
 
 module Log = struct
   module type S = Trait_log.S
+
+  type (_, _, _) Provider.Trait.t +=
+    | Log : ('t, (module S with type t = 't), [> log ]) Provider.Trait.t
+
+  let t = Log
 end
 
 type ls_files = [ `Ls_files of ls_files_ty ]
@@ -80,6 +120,11 @@ and ls_files_ty
 
 module Ls_files = struct
   module type S = Trait_ls_files.S
+
+  type (_, _, _) Provider.Trait.t +=
+    | Ls_files : ('t, (module S with type t = 't), [> ls_files ]) Provider.Trait.t
+
+  let t = Ls_files
 end
 
 type name_status = [ `Name_status of name_status_ty ]
@@ -87,6 +132,11 @@ and name_status_ty
 
 module Name_status = struct
   module type S = Trait_name_status.S
+
+  type (_, _, _) Provider.Trait.t +=
+    | Name_status : ('t, (module S with type t = 't), [> name_status ]) Provider.Trait.t
+
+  let t = Name_status
 end
 
 type num_status = [ `Num_status of num_status_ty ]
@@ -94,6 +144,11 @@ and num_status_ty
 
 module Num_status = struct
   module type S = Trait_num_status.S
+
+  type (_, _, _) Provider.Trait.t +=
+    | Num_status : ('t, (module S with type t = 't), [> num_status ]) Provider.Trait.t
+
+  let t = Num_status
 end
 
 type refs = [ `Refs of refs_ty ]
@@ -101,6 +156,11 @@ and refs_ty
 
 module Refs = struct
   module type S = Trait_refs.S
+
+  type (_, _, _) Provider.Trait.t +=
+    | Refs : ('t, (module S with type t = 't), [> refs ]) Provider.Trait.t
+
+  let t = Refs
 end
 
 type rev_parse = [ `Rev_parse of rev_parse_ty ]
@@ -108,6 +168,11 @@ and rev_parse_ty
 
 module Rev_parse = struct
   module type S = Trait_rev_parse.S
+
+  type (_, _, _) Provider.Trait.t +=
+    | Rev_parse : ('t, (module S with type t = 't), [> rev_parse ]) Provider.Trait.t
+
+  let t = Rev_parse
 end
 
 type show = [ `Show of show_ty ]
@@ -115,27 +180,12 @@ and show_ty
 
 module Show = struct
   module type S = Trait_show.S
-end
 
-type (_, _, _) Provider.Trait.t +=
-  | Add : ('t, (module Add.S with type t = 't), [> add ]) Provider.Trait.t
-  | Branch : ('t, (module Branch.S with type t = 't), [> branch ]) Provider.Trait.t
-  | Commit : ('t, (module Commit.S with type t = 't), [> commit ]) Provider.Trait.t
-  | Config : ('t, (module Config.S with type t = 't), [> config ]) Provider.Trait.t
-  | File_system :
-      ('t, (module File_system.S with type t = 't), [> file_system ]) Provider.Trait.t
-  | Git : ('t, (module Git.S with type t = 't), [> git ]) Provider.Trait.t
-  | Init : ('t, (module Init.S with type t = 't), [> init ]) Provider.Trait.t
-  | Log : ('t, (module Log.S with type t = 't), [> log ]) Provider.Trait.t
-  | Ls_files : ('t, (module Ls_files.S with type t = 't), [> ls_files ]) Provider.Trait.t
-  | Name_status :
-      ('t, (module Name_status.S with type t = 't), [> name_status ]) Provider.Trait.t
-  | Num_status :
-      ('t, (module Num_status.S with type t = 't), [> num_status ]) Provider.Trait.t
-  | Refs : ('t, (module Refs.S with type t = 't), [> refs ]) Provider.Trait.t
-  | Rev_parse :
-      ('t, (module Rev_parse.S with type t = 't), [> rev_parse ]) Provider.Trait.t
-  | Show : ('t, (module Show.S with type t = 't), [> show ]) Provider.Trait.t
+  type (_, _, _) Provider.Trait.t +=
+    | Show : ('t, (module S with type t = 't), [> show ]) Provider.Trait.t
+
+  let t = Show
+end
 
 type t =
   [ add

--- a/lib/vcs/src/trait.mli
+++ b/lib/vcs/src/trait.mli
@@ -34,6 +34,8 @@ and add_ty
 
 module Add : sig
   module type S = Trait_add.S
+
+  val t : ('t, (module S with type t = 't), [> add ]) Provider.Trait.t
 end
 
 type branch = [ `Branch of branch_ty ]
@@ -41,6 +43,8 @@ and branch_ty
 
 module Branch : sig
   module type S = Trait_branch.S
+
+  val t : ('t, (module S with type t = 't), [> branch ]) Provider.Trait.t
 end
 
 type commit = [ `Commit of commit_ty ]
@@ -48,6 +52,8 @@ and commit_ty
 
 module Commit : sig
   module type S = Trait_commit.S
+
+  val t : ('t, (module S with type t = 't), [> commit ]) Provider.Trait.t
 end
 
 type config = [ `Config of config_ty ]
@@ -55,6 +61,8 @@ and config_ty
 
 module Config : sig
   module type S = Trait_config.S
+
+  val t : ('t, (module S with type t = 't), [> config ]) Provider.Trait.t
 end
 
 type file_system = [ `File_system of file_system_ty ]
@@ -62,6 +70,8 @@ and file_system_ty
 
 module File_system : sig
   module type S = Trait_file_system.S
+
+  val t : ('t, (module S with type t = 't), [> file_system ]) Provider.Trait.t
 end
 
 type git = [ `Git of git_ty ]
@@ -69,6 +79,8 @@ and git_ty
 
 module Git : sig
   module type S = Trait_git.S
+
+  val t : ('t, (module S with type t = 't), [> git ]) Provider.Trait.t
 end
 
 type init = [ `Init of init_ty ]
@@ -76,6 +88,8 @@ and init_ty
 
 module Init : sig
   module type S = Trait_init.S
+
+  val t : ('t, (module S with type t = 't), [> init ]) Provider.Trait.t
 end
 
 type log = [ `Log of log_ty ]
@@ -83,6 +97,8 @@ and log_ty
 
 module Log : sig
   module type S = Trait_log.S
+
+  val t : ('t, (module S with type t = 't), [> log ]) Provider.Trait.t
 end
 
 type ls_files = [ `Ls_files of ls_files_ty ]
@@ -90,6 +106,8 @@ and ls_files_ty
 
 module Ls_files : sig
   module type S = Trait_ls_files.S
+
+  val t : ('t, (module S with type t = 't), [> ls_files ]) Provider.Trait.t
 end
 
 type name_status = [ `Name_status of name_status_ty ]
@@ -97,6 +115,8 @@ and name_status_ty
 
 module Name_status : sig
   module type S = Trait_name_status.S
+
+  val t : ('t, (module S with type t = 't), [> name_status ]) Provider.Trait.t
 end
 
 type num_status = [ `Num_status of num_status_ty ]
@@ -104,6 +124,8 @@ and num_status_ty
 
 module Num_status : sig
   module type S = Trait_num_status.S
+
+  val t : ('t, (module S with type t = 't), [> num_status ]) Provider.Trait.t
 end
 
 type refs = [ `Refs of refs_ty ]
@@ -111,6 +133,8 @@ and refs_ty
 
 module Refs : sig
   module type S = Trait_refs.S
+
+  val t : ('t, (module S with type t = 't), [> refs ]) Provider.Trait.t
 end
 
 type rev_parse = [ `Rev_parse of rev_parse_ty ]
@@ -118,6 +142,8 @@ and rev_parse_ty
 
 module Rev_parse : sig
   module type S = Trait_rev_parse.S
+
+  val t : ('t, (module S with type t = 't), [> rev_parse ]) Provider.Trait.t
 end
 
 type show = [ `Show of show_ty ]
@@ -125,27 +151,9 @@ and show_ty
 
 module Show : sig
   module type S = Trait_show.S
-end
 
-type (_, _, _) Provider.Trait.t +=
-  | Add : ('t, (module Add.S with type t = 't), [> add ]) Provider.Trait.t
-  | Branch : ('t, (module Branch.S with type t = 't), [> branch ]) Provider.Trait.t
-  | Commit : ('t, (module Commit.S with type t = 't), [> commit ]) Provider.Trait.t
-  | Config : ('t, (module Config.S with type t = 't), [> config ]) Provider.Trait.t
-  | File_system :
-      ('t, (module File_system.S with type t = 't), [> file_system ]) Provider.Trait.t
-  | Git : ('t, (module Git.S with type t = 't), [> git ]) Provider.Trait.t
-  | Init : ('t, (module Init.S with type t = 't), [> init ]) Provider.Trait.t
-  | Log : ('t, (module Log.S with type t = 't), [> log ]) Provider.Trait.t
-  | Ls_files : ('t, (module Ls_files.S with type t = 't), [> ls_files ]) Provider.Trait.t
-  | Name_status :
-      ('t, (module Name_status.S with type t = 't), [> name_status ]) Provider.Trait.t
-  | Num_status :
-      ('t, (module Num_status.S with type t = 't), [> num_status ]) Provider.Trait.t
-  | Refs : ('t, (module Refs.S with type t = 't), [> refs ]) Provider.Trait.t
-  | Rev_parse :
-      ('t, (module Rev_parse.S with type t = 't), [> rev_parse ]) Provider.Trait.t
-  | Show : ('t, (module Show.S with type t = 't), [> show ]) Provider.Trait.t
+  val t : ('t, (module S with type t = 't), [> show ]) Provider.Trait.t
+end
 
 (** The union of all traits defined in Vcs. *)
 type t =

--- a/lib/vcs/src/vcs.mli
+++ b/lib/vcs/src/vcs.mli
@@ -32,9 +32,9 @@ module Trait = Trait
 (** At its core, a ['a Vcs.t] is a value encapsulating the functionalities
     implemented by a set of traits, represented by the ['a] parameter. It is a
     phantom type used to provide compiler guidance on which functions from the
-    API you can use with such a [vcs]. The type is contravariant by its
-    parameter : indeed, if you need a set of traits, having more makes it
-    compatible. *)
+    API you can use with such a [vcs]. The type is contravariant in its
+    parameter : indeed, if you need a set of traits, having access to a
+    provider implementing more traits makes it compatible. *)
 type -'a t = 'a Vcs0.t
 
 (** [create provider] returns a [vcs] that implements a given set of traits.

--- a/lib/vcs/src/vcs0.ml
+++ b/lib/vcs/src/vcs0.ml
@@ -31,13 +31,13 @@ let of_result ~step = function
 ;;
 
 let load_file (Provider.T { t; handler }) ~path =
-  let module M = (val Provider.Handler.lookup handler ~trait:Trait.File_system) in
+  let module M = (val Provider.Handler.lookup handler ~trait:Trait.File_system.t) in
   M.load_file t ~path
   |> of_result ~step:(lazy [%sexp "Vcs.load_file", { path : Absolute_path.t }])
 ;;
 
 let save_file ?perms (Provider.T { t; handler }) ~path ~file_contents =
-  let module M = (val Provider.Handler.lookup handler ~trait:Trait.File_system) in
+  let module M = (val Provider.Handler.lookup handler ~trait:Trait.File_system.t) in
   M.save_file ?perms t ~path ~file_contents
   |> of_result
        ~step:
@@ -45,20 +45,20 @@ let save_file ?perms (Provider.T { t; handler }) ~path ~file_contents =
 ;;
 
 let read_dir (Provider.T { t; handler }) ~dir =
-  let module M = (val Provider.Handler.lookup handler ~trait:Trait.File_system) in
+  let module M = (val Provider.Handler.lookup handler ~trait:Trait.File_system.t) in
   M.read_dir t ~dir
   |> of_result ~step:(lazy [%sexp "Vcs.read_dir", { dir : Absolute_path.t }])
 ;;
 
 let add (Provider.T { t; handler }) ~repo_root ~path =
-  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Add) in
+  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Add.t) in
   M.add t ~repo_root ~path
   |> of_result
        ~step:(lazy [%sexp "Vcs.add", { repo_root : Repo_root.t; path : Path_in_repo.t }])
 ;;
 
 let init (Provider.T { t; handler }) ~path =
-  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Init) in
+  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Init.t) in
   M.init t ~path |> of_result ~step:(lazy [%sexp "Vcs.init", { path : Absolute_path.t }])
 ;;
 
@@ -92,20 +92,20 @@ let find_enclosing_git_repo_root t ~from =
 ;;
 
 let current_branch (Provider.T { t; handler }) ~repo_root =
-  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Rev_parse) in
+  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Rev_parse.t) in
   M.current_branch t ~repo_root
   |> of_result ~step:(lazy [%sexp "Vcs.current_branch", { repo_root : Repo_root.t }])
 ;;
 
 let current_revision (Provider.T { t; handler }) ~repo_root =
-  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Rev_parse) in
+  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Rev_parse.t) in
   M.current_revision t ~repo_root
   |> of_result ~step:(lazy [%sexp "Vcs.current_revision", { repo_root : Repo_root.t }])
 ;;
 
 let commit (Provider.T { t; handler }) ~repo_root ~commit_message =
-  let module R = (val Provider.Handler.lookup handler ~trait:Trait.Rev_parse) in
-  let module C = (val Provider.Handler.lookup handler ~trait:Trait.Commit) in
+  let module R = (val Provider.Handler.lookup handler ~trait:Trait.Rev_parse.t) in
+  let module C = (val Provider.Handler.lookup handler ~trait:Trait.Commit.t) in
   (let open Result.Monad_syntax in
    let* () = C.commit t ~repo_root ~commit_message in
    R.current_revision t ~repo_root)
@@ -113,7 +113,7 @@ let commit (Provider.T { t; handler }) ~repo_root ~commit_message =
 ;;
 
 let ls_files (Provider.T { t; handler }) ~repo_root ~below =
-  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Ls_files) in
+  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Ls_files.t) in
   M.ls_files t ~repo_root ~below
   |> of_result
        ~step:
@@ -122,7 +122,7 @@ let ls_files (Provider.T { t; handler }) ~repo_root ~below =
 ;;
 
 let rename_current_branch (Provider.T { t; handler }) ~repo_root ~to_ =
-  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Branch) in
+  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Branch.t) in
   M.rename_current_branch t ~repo_root ~to_
   |> of_result
        ~step:
@@ -132,7 +132,7 @@ let rename_current_branch (Provider.T { t; handler }) ~repo_root ~to_ =
 ;;
 
 let name_status (Provider.T { t; handler }) ~repo_root ~changed =
-  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Name_status) in
+  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Name_status.t) in
   M.diff t ~repo_root ~changed
   |> of_result
        ~step:
@@ -143,7 +143,7 @@ let name_status (Provider.T { t; handler }) ~repo_root ~changed =
 ;;
 
 let num_status (Provider.T { t; handler }) ~repo_root ~changed =
-  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Num_status) in
+  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Num_status.t) in
   M.diff t ~repo_root ~changed
   |> of_result
        ~step:
@@ -153,20 +153,20 @@ let num_status (Provider.T { t; handler }) ~repo_root ~changed =
 ;;
 
 let log (Provider.T { t; handler }) ~repo_root =
-  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Log) in
+  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Log.t) in
   M.all t ~repo_root
   |> of_result ~step:(lazy [%sexp "Vcs.log", { repo_root : Repo_root.t }])
 ;;
 
 let refs (Provider.T { t; handler }) ~repo_root =
-  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Refs) in
+  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Refs.t) in
   M.show_ref t ~repo_root
   |> of_result ~step:(lazy [%sexp "Vcs.refs", { repo_root : Repo_root.t }])
 ;;
 
 let graph (Provider.T { t; handler }) ~repo_root =
-  let module L = (val Provider.Handler.lookup handler ~trait:Trait.Log) in
-  let module R = (val Provider.Handler.lookup handler ~trait:Trait.Refs) in
+  let module L = (val Provider.Handler.lookup handler ~trait:Trait.Log.t) in
+  let module R = (val Provider.Handler.lookup handler ~trait:Trait.Refs.t) in
   let graph = Graph.create () in
   (let open Result.Monad_syntax in
    let* log = L.all t ~repo_root in
@@ -178,7 +178,7 @@ let graph (Provider.T { t; handler }) ~repo_root =
 ;;
 
 let set_user_name (Provider.T { t; handler }) ~repo_root ~user_name =
-  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Config) in
+  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Config.t) in
   M.set_user_name t ~repo_root ~user_name
   |> of_result
        ~step:
@@ -188,7 +188,7 @@ let set_user_name (Provider.T { t; handler }) ~repo_root ~user_name =
 ;;
 
 let set_user_email (Provider.T { t; handler }) ~repo_root ~user_email =
-  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Config) in
+  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Config.t) in
   M.set_user_email t ~repo_root ~user_email
   |> of_result
        ~step:
@@ -198,7 +198,7 @@ let set_user_email (Provider.T { t; handler }) ~repo_root ~user_email =
 ;;
 
 let show_file_at_rev (Provider.T { t; handler }) ~repo_root ~rev ~path =
-  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Show) in
+  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Show.t) in
   M.show_file_at_rev t ~repo_root ~rev ~path
   |> of_result
        ~step:
@@ -226,7 +226,7 @@ let non_raising_git
   ~args
   ~f
   =
-  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Git) in
+  let module M = (val Provider.Handler.lookup handler ~trait:Trait.Git.t) in
   let cwd = Repo_root.append repo_root run_in_subdir in
   M.git ?env t ~cwd ~args ~f
 ;;

--- a/lib/vcs_git_provider/src/vcs_git_provider.ml
+++ b/lib/vcs_git_provider/src/vcs_git_provider.ml
@@ -78,20 +78,20 @@ module Make (Runtime : Runtime.S) = struct
 
   let handler () : (t, [> Trait.t ]) Provider.Handler.t =
     Provider.Handler.make
-      [ Provider.Trait.implement Vcs.Trait.Add ~impl:(module Impl.Add)
-      ; Provider.Trait.implement Vcs.Trait.Branch ~impl:(module Impl.Branch)
-      ; Provider.Trait.implement Vcs.Trait.Commit ~impl:(module Impl.Commit)
-      ; Provider.Trait.implement Vcs.Trait.Config ~impl:(module Impl.Config)
-      ; Provider.Trait.implement Vcs.Trait.File_system ~impl:(module Impl.File_system)
-      ; Provider.Trait.implement Vcs.Trait.Git ~impl:(module Impl.Git)
-      ; Provider.Trait.implement Vcs.Trait.Init ~impl:(module Impl.Init)
-      ; Provider.Trait.implement Vcs.Trait.Log ~impl:(module Impl.Log)
-      ; Provider.Trait.implement Vcs.Trait.Ls_files ~impl:(module Impl.Ls_files)
-      ; Provider.Trait.implement Vcs.Trait.Name_status ~impl:(module Impl.Name_status)
-      ; Provider.Trait.implement Vcs.Trait.Num_status ~impl:(module Impl.Num_status)
-      ; Provider.Trait.implement Vcs.Trait.Refs ~impl:(module Impl.Refs)
-      ; Provider.Trait.implement Vcs.Trait.Rev_parse ~impl:(module Impl.Rev_parse)
-      ; Provider.Trait.implement Vcs.Trait.Show ~impl:(module Impl.Show)
+      [ Provider.Trait.implement Vcs.Trait.Add.t ~impl:(module Impl.Add)
+      ; Provider.Trait.implement Vcs.Trait.Branch.t ~impl:(module Impl.Branch)
+      ; Provider.Trait.implement Vcs.Trait.Commit.t ~impl:(module Impl.Commit)
+      ; Provider.Trait.implement Vcs.Trait.Config.t ~impl:(module Impl.Config)
+      ; Provider.Trait.implement Vcs.Trait.File_system.t ~impl:(module Impl.File_system)
+      ; Provider.Trait.implement Vcs.Trait.Git.t ~impl:(module Impl.Git)
+      ; Provider.Trait.implement Vcs.Trait.Init.t ~impl:(module Impl.Init)
+      ; Provider.Trait.implement Vcs.Trait.Log.t ~impl:(module Impl.Log)
+      ; Provider.Trait.implement Vcs.Trait.Ls_files.t ~impl:(module Impl.Ls_files)
+      ; Provider.Trait.implement Vcs.Trait.Name_status.t ~impl:(module Impl.Name_status)
+      ; Provider.Trait.implement Vcs.Trait.Num_status.t ~impl:(module Impl.Num_status)
+      ; Provider.Trait.implement Vcs.Trait.Refs.t ~impl:(module Impl.Refs)
+      ; Provider.Trait.implement Vcs.Trait.Rev_parse.t ~impl:(module Impl.Rev_parse)
+      ; Provider.Trait.implement Vcs.Trait.Show.t ~impl:(module Impl.Show)
       ]
   ;;
 

--- a/vcs-command.opam
+++ b/vcs-command.opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "5.2"}
   "cmdlang" {>= "0.0.5"}
   "cmdlang-cmdliner-runner" {>= "0.0.5"}
-  "cmdliner" {= "1.3.0"}
+  "cmdliner" {>= "1.3.0"}
   "eio" {>= "1.0"}
   "eio_main" {>= "1.0"}
   "err" {>= "0.0.5"}

--- a/vcs-tests.opam
+++ b/vcs-tests.opam
@@ -17,7 +17,7 @@ depends: [
   "cmdlang" {>= "0.0.5"}
   "cmdlang-cmdliner-runner" {>= "0.0.5"}
   "cmdlang-to-cmdliner" {>= "0.0.5"}
-  "cmdliner" {= "1.3.0"}
+  "cmdliner" {>= "1.3.0"}
   "core" {>= "v0.17" & < "v0.18"}
   "eio" {>= "1.0"}
   "eio_main" {>= "1.0"}


### PR DESCRIPTION
Replace the OCaml variant constructor by value of the right type, but keeping their representation hidden.

No user facing change.

## Motivation

There is some work happening in the provider dependency that may change the nature of what's a `Trait.t` constructor. In some versions, this is no longer an OCaml variant constructor. With this change, we reduce the exposure of vcs into the choices made in provider, and simplify future upgrades.