### PR TITLE
Add missing transitive dependencies

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -3,6 +3,6 @@
  (public_name ocaml-vcs)
  (package vcs-command)
  (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a)
- (libraries cmdlang-cmdliner-runner pp-log.err vcs-command)
+ (libraries cmdlang-cmdliner-runner pp-log.err vcs vcs-command)
  (instrumentation
   (backend bisect_ppx)))

--- a/dune-project
+++ b/dune-project
@@ -23,6 +23,8 @@
  (depends
   (ocaml
    (>= 5.2))
+  (astring
+   (>= 0.8.5))
   (fpath
    (>= 0.7.3))
   (fpath-sexp0
@@ -156,6 +158,8 @@
     (< v0.18)))
   (ppxlib
    (>= 0.33))
+  (provider
+   (>= 0.0.11))
   (sexplib0
    (and
     (>= v0.17)
@@ -239,6 +243,8 @@
    (and
     :with-dev-setup
     (= 0.27.0)))
+  (astring
+   (>= 0.8.5))
   (base
    (and
     (>= v0.17)

--- a/example/dune
+++ b/example/dune
@@ -23,6 +23,7 @@
   expect_test_helpers_core.expect_test_helpers_base
   fpath
   fpath-sexp0
+  unix
   vcs
   vcs_base
   vcs_git_blocking

--- a/lib/vcs/src/dune
+++ b/lib/vcs/src/dune
@@ -13,7 +13,7 @@
   Sexplib0
   -open
   Sexplib0.Sexp_conv)
- (libraries fpath fpath-sexp0 provider)
+ (libraries astring fpath fpath-sexp0 provider)
  (instrumentation
   (backend bisect_ppx))
  (lint

--- a/lib/vcs_command/src/dune
+++ b/lib/vcs_command/src/dune
@@ -15,7 +15,7 @@
   Sexplib0
   -open
   Sexplib0.Sexp_conv)
- (libraries cmdlang eio eio_main fpath-sexp0 sexplib0 vcs vcs-git-eio)
+ (libraries cmdlang eio eio_main fpath-sexp0 sexplib0 unix vcs vcs-git-eio)
  (instrumentation
   (backend bisect_ppx))
  (lint

--- a/lib/vcs_git_blocking/test/dune
+++ b/lib/vcs_git_blocking/test/dune
@@ -19,6 +19,7 @@
   expect_test_helpers_core.expect_test_helpers_base
   fpath
   fpath-sexp0
+  unix
   vcs
   vcs_git_blocking
   vcs_test_helpers)

--- a/lib/vcs_git_eio/src/dune
+++ b/lib/vcs_git_eio/src/dune
@@ -13,7 +13,7 @@
   Sexplib0
   -open
   Sexplib0.Sexp_conv)
- (libraries eio fpath fpath-sexp0 sexplib0 vcs vcs-git-provider)
+ (libraries eio fpath fpath-sexp0 provider sexplib0 vcs vcs-git-provider)
  (instrumentation
   (backend bisect_ppx))
  (lint

--- a/lib/vcs_git_eio/test/dune
+++ b/lib/vcs_git_eio/test/dune
@@ -21,6 +21,7 @@
   expect_test_helpers_core.expect_test_helpers_base
   fpath
   fpath-sexp0
+  unix
   vcs
   vcs_git_eio
   vcs_test_helpers)

--- a/lib/vcs_git_provider/src/dune
+++ b/lib/vcs_git_provider/src/dune
@@ -13,7 +13,7 @@
   Sexplib0
   -open
   Sexplib0.Sexp_conv)
- (libraries astring fpath fpath-sexp0 sexplib0 vcs)
+ (libraries astring fpath fpath-sexp0 provider sexplib0 vcs)
  (instrumentation
   (backend bisect_ppx))
  (lint

--- a/vcs-git-provider.opam
+++ b/vcs-git-provider.opam
@@ -16,6 +16,7 @@ depends: [
   "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
   "ppxlib" {>= "0.33"}
+  "provider" {>= "0.0.11"}
   "sexplib0" {>= "v0.17" & < "v0.18"}
   "vcs" {= version}
   "odoc" {with-doc}

--- a/vcs-tests.opam
+++ b/vcs-tests.opam
@@ -11,6 +11,7 @@ depends: [
   "dune" {>= "3.16"}
   "ocaml" {>= "5.2"}
   "ocamlformat" {with-dev-setup & = "0.27.0"}
+  "astring" {>= "0.8.5"}
   "base" {>= "v0.17" & < "v0.18"}
   "base_quickcheck" {>= "v0.17" & < "v0.18"}
   "bisect_ppx" {with-dev-setup & >= "2.8.3"}

--- a/vcs.opam
+++ b/vcs.opam
@@ -10,6 +10,7 @@ bug-reports: "https://github.com/mbarbin/vcs/issues"
 depends: [
   "dune" {>= "3.16"}
   "ocaml" {>= "5.2"}
+  "astring" {>= "0.8.5"}
   "fpath" {>= "0.7.3"}
   "fpath-sexp0" {>= "0.2.2"}
   "ppx_enumerate" {>= "v0.17" & < "v0.18"}


### PR DESCRIPTION
Add missing dependencies, in preparation for enabling `(implicit_transitive_deps false)` with `dune.3.17`.