### PR TITLE
Allow git-blocking calls to be run in parallel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Allow `vcs-git-blocking` calls to be run in parallel (#PR, @mbarbin).
+
 ### Removed
 
 ## 0.0.10 (2024-11-05)

--- a/dune-project
+++ b/dune-project
@@ -230,6 +230,10 @@
    (and
     (>= v0.17)
     (< v0.18)))
+  (shexp
+   (and
+    (>= v0.17)
+    (< v0.18)))
   (vcs
    (= :version))
   (vcs-git-provider

--- a/example/hello_blocking.ml
+++ b/example/hello_blocking.ml
@@ -80,7 +80,7 @@ let%expect_test "hello commit" =
         (cwd         /invalid/path/)
         (stdout      "")
         (stderr      ""))))
-     (error ("Unix.Unix_error(Unix.ENOENT, \"chdir\", \"/invalid/path/\")")))
+     (error ("Unix.Unix_error(Unix.ENOENT, \"open\", \"/invalid/path/\")")))
     |}];
   (* Let's also show a case where the command fails due to a user error. *)
   let () =

--- a/lib/vcs_git_blocking/src/dune
+++ b/lib/vcs_git_blocking/src/dune
@@ -13,7 +13,14 @@
   Sexplib0
   -open
   Sexplib0.Sexp_conv)
- (libraries fpath fpath-sexp0 provider unix vcs vcs-git-provider)
+ (libraries
+  fpath
+  fpath-sexp0
+  provider
+  shexp.process
+  unix
+  vcs
+  vcs-git-provider)
  (instrumentation
   (backend bisect_ppx))
  (lint

--- a/vcs-git-blocking.opam
+++ b/vcs-git-blocking.opam
@@ -18,6 +18,7 @@ depends: [
   "ppxlib" {>= "0.33"}
   "provider" {>= "0.0.11"}
   "sexplib0" {>= "v0.17" & < "v0.18"}
+  "shexp" {>= "v0.17" & < "v0.18"}
   "vcs" {= version}
   "vcs-git-provider" {= version}
   "odoc" {with-doc}


### PR DESCRIPTION
Replace non-thread safe previous `with_cwd` implementation by the context construct implemented by `shexp.process`.