### PR TITLE
Switch vcs-cli backend to vcs-git-blocking

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Switch the backend used in `vcs-cli` from `eio` to `blocking` (#<PR>, @mbarbin).
 - Pre-locate the git executable in `vcs_git_blocking` (#52, @mbarbin).
 
 ### Deprecated

--- a/dune-project
+++ b/dune-project
@@ -105,20 +105,12 @@
    (>= 5.2))
   (cmdlang
    (>= 0.0.9))
-  (eio
-   (>= 1.0))
-  (eio_main
-   (>= 1.0))
   (fpath
    (>= 0.7.3))
   (fpath-sexp0
    (>= 0.2.2))
   (pplumbing
    (>= 0.0.9))
-  (ppx_sexp_conv
-   (and
-    (>= v0.17)
-    (< v0.18)))
   (ppx_sexp_value
    (and
     (>= v0.17)
@@ -131,7 +123,7 @@
     (< v0.18)))
   (vcs
    (= :version))
-  (vcs-git-eio
+  (vcs-git-blocking
    (= :version))))
 
 (package

--- a/lib/vcs_cli/src/dune
+++ b/lib/vcs_cli/src/dune
@@ -15,10 +15,10 @@
   Sexplib0
   -open
   Sexplib0.Sexp_conv)
- (libraries cmdlang eio eio_main fpath-sexp0 sexplib0 unix vcs vcs-git-eio)
+ (libraries cmdlang fpath-sexp0 sexplib0 unix vcs vcs-git-blocking)
  (instrumentation
   (backend bisect_ppx))
  (lint
   (pps ppx_js_style -allow-let-operators -check-doc-comments))
  (preprocess
-  (pps -unused-code-warnings=force ppx_sexp_conv ppx_sexp_value)))
+  (pps ppx_sexp_value)))

--- a/test/cram/run.t
+++ b/test/cram/run.t
@@ -62,8 +62,8 @@ File system operations.
       ((dir
         $TESTCASE_ROOT/untracked)))))
    (error
-    ( "Eio.Io Fs Not_found Unix_error (No such file or directory, \"openat2\", \"\"),\
-     \n  reading directory <fs:$TESTCASE_ROOT/untracked>")))
+    (Sys_error
+     "$TESTCASE_ROOT/untracked: No such file or directory")))
   [123]
 
   $ mkdir -p untracked
@@ -83,8 +83,8 @@ File system operations.
       ((dir
         $TESTCASE_ROOT/untracked/hello)))))
    (error
-    ( "Eio.Io Unix_error (Not a directory, \"openat2\", \"\"),\
-     \n  reading directory <fs:$TESTCASE_ROOT/untracked/hello>")))
+    (Sys_error
+     "$TESTCASE_ROOT/untracked/hello: Not a directory")))
   [123]
 
   $ ocaml-vcs load-file untracked/hello
@@ -98,8 +98,8 @@ File system operations.
       ((dir
         $TESTCASE_ROOT/untracked)))))
    (error
-    ( "Eio.Io Fs Permission_denied Unix_error (Permission denied, \"openat2\", \"\"),\
-     \n  reading directory <fs:$TESTCASE_ROOT/untracked>")))
+    (Sys_error
+     "$TESTCASE_ROOT/untracked: Permission denied")))
   [123]
 
   $ rm untracked/hello

--- a/vcs-cli.opam
+++ b/vcs-cli.opam
@@ -11,17 +11,14 @@ depends: [
   "dune" {>= "3.17"}
   "ocaml" {>= "5.2"}
   "cmdlang" {>= "0.0.9"}
-  "eio" {>= "1.0"}
-  "eio_main" {>= "1.0"}
   "fpath" {>= "0.7.3"}
   "fpath-sexp0" {>= "0.2.2"}
   "pplumbing" {>= "0.0.9"}
-  "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
   "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
   "ppxlib" {>= "0.33"}
   "sexplib0" {>= "v0.17" & < "v0.18"}
   "vcs" {= version}
-  "vcs-git-eio" {= version}
+  "vcs-git-blocking" {= version}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
I've started using vcs-cli as test dependencies in other repos, and thus am interested in reducing the overall dependencies footprint. As it turns out, I didn't really use Eio in this package, so simplifying now.