### PR TITLE
Tweak err format

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,17 @@
+## 0.0.14 (unreleased)
+
+### Added
+
+### Changed
+
+- Make some tweaks to vcs errors and exns sexp formats (#57, @mbarbin).
+
+### Deprecated
+
+### Fixed
+
+### Removed
+
 ## 0.0.13 (2025-05-02)
 
 ### Changed

--- a/example/hello_error.ml
+++ b/example/hello_error.ml
@@ -40,14 +40,14 @@ let%expect_test "hello error" =
   in
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.init ((path /invalid/path)))
        ((prog git)
         (args (init .))
         (exit_status Unknown)
         (cwd         /invalid/path)
         (stdout      "")
-        (stderr      ""))))
+        (stderr      "")))
      (error <REDACTED>))
     |}];
   (* Let's do the same with the non-raising interfaces. *)
@@ -58,14 +58,14 @@ let%expect_test "hello error" =
   in
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.init ((path /invalid/path)))
        ((prog git)
         (args (init .))
         (exit_status Unknown)
         (cwd         /invalid/path)
         (stdout      "")
-        (stderr      ""))))
+        (stderr      "")))
      (error <REDACTED>))
     |}];
   let () =
@@ -75,14 +75,14 @@ let%expect_test "hello error" =
   in
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.init ((path /invalid/path)))
        ((prog git)
         (args (init .))
         (exit_status Unknown)
         (cwd         /invalid/path)
         (stdout      "")
-        (stderr      ""))))
+        (stderr      "")))
      (error <REDACTED>))
     |}];
   let () =
@@ -93,14 +93,14 @@ let%expect_test "hello error" =
   [%expect
     {|
     (Vcs (
-      (steps (
+      (context
         (Vcs.init ((path /invalid/path)))
         ((prog git)
          (args (init .))
          (exit_status Unknown)
          (cwd         /invalid/path)
          (stdout      "")
-         (stderr      ""))))
+         (stderr      "")))
       (error <REDACTED>)))
     |}];
   ()

--- a/example/hello_git_cli.ml
+++ b/example/hello_git_cli.ml
@@ -106,14 +106,14 @@ let%expect_test "hello cli" =
   in
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.git ((repo_root <REDACTED>) (args (rev-parse INVALID-REF))))
        ((prog git)
         (args        (rev-parse INVALID-REF))
         (exit_status (Exited    128))
         (cwd    <REDACTED>)
         (stdout INVALID-REF)
-        (stderr <REDACTED>))))
+        (stderr <REDACTED>)))
      (error (Failure "Hello invalid exit code")))
     |}];
   let () =
@@ -136,14 +136,14 @@ let%expect_test "hello cli" =
   in
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.git ((repo_root <REDACTED>) (args (rev-parse INVALID-REF))))
        ((prog git)
         (args        (rev-parse INVALID-REF))
         (exit_status (Exited    128))
         (cwd    <REDACTED>)
         (stdout INVALID-REF)
-        (stderr <REDACTED>))))
+        (stderr <REDACTED>)))
      (error "Hello invalid exit code"))
     |}];
   let () =
@@ -162,14 +162,14 @@ let%expect_test "hello cli" =
   in
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.git ((repo_root <REDACTED>) (args (rev-parse INVALID-REF))))
        ((prog git)
         (args        (rev-parse INVALID-REF))
         (exit_status (Exited    128))
         (cwd    <REDACTED>)
         (stdout INVALID-REF)
-        (stderr <REDACTED>))))
+        (stderr <REDACTED>)))
      (error "Hello invalid exit code"))
     |}];
   let () =
@@ -192,14 +192,14 @@ let%expect_test "hello cli" =
   in
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.git ((repo_root <REDACTED>) (args (rev-parse INVALID-REF))))
        ((prog git)
         (args        (rev-parse INVALID-REF))
         (exit_status (Exited    128))
         (cwd    <REDACTED>)
         (stdout INVALID-REF)
-        (stderr <REDACTED>))))
+        (stderr <REDACTED>)))
      (error "Hello invalid exit code"))
     |}];
   (* Here we characterize some unintended ways the API may be abused. *)
@@ -226,14 +226,14 @@ let%expect_test "hello cli" =
   in
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.git ((repo_root /bogus) (args (rev-parse --abbrev-ref HEAD))))
        ((prog git)
         (args (rev-parse --abbrev-ref HEAD))
         (exit_status Unknown)
         (cwd         /bogus/)
         (stdout      "")
-        (stderr      ""))))
+        (stderr      "")))
      (error <REDACTED>))
     |}];
   (* Another difference is that you do not get the context when the [f] helper
@@ -262,14 +262,14 @@ let%expect_test "hello cli" =
   [%expect
     {|
     (Error (
-      (steps (
+      (context
         (Vcs.git ((repo_root /bogus) (args (rev-parse --abbrev-ref HEAD))))
         ((prog git)
          (args (rev-parse --abbrev-ref HEAD))
          (exit_status Unknown)
          (cwd         /bogus/)
          (stdout      "")
-         (stderr      ""))))
+         (stderr      "")))
       (error <REDACTED>)))
     |}];
   (* And you do get the context when the helper returns an error. *)
@@ -284,14 +284,14 @@ let%expect_test "hello cli" =
        ~fields:[ "cwd"; "repo_root"; "stderr" ]);
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.git ((repo_root <REDACTED>) (args (rev-parse --abbrev-ref bogus))))
        ((prog git)
         (args (rev-parse --abbrev-ref bogus))
         (exit_status (Exited 128))
         (cwd    <REDACTED>)
         (stdout bogus)
-        (stderr <REDACTED>))))
+        (stderr <REDACTED>)))
      (error "expected exit code 0"))
     |}];
   (* 2. Let's look now at [Vcs.Or_error.git]. It is meant to be used with a
@@ -320,14 +320,14 @@ let%expect_test "hello cli" =
   [%expect
     {|
     (Error (
-      (steps (
+      (context
         (Vcs.git ((repo_root /bogus) (args (rev-parse --abbrev-ref HEAD))))
         ((prog git)
          (args (rev-parse --abbrev-ref HEAD))
          (exit_status Unknown)
          (cwd         /bogus/)
          (stdout      "")
-         (stderr      ""))))
+         (stderr      "")))
       (error <REDACTED>)))
     |}];
   (* However when your handler [f] raises, the function will raise too, and you
@@ -361,27 +361,27 @@ let%expect_test "hello cli" =
     ~redact_fields:[ "cwd"; "error"; "repo_root"; "stderr" ];
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.git ((repo_root <REDACTED>) (args (rev-parse --abbrev-ref HEAD))))
        ((prog git)
         (args (rev-parse --abbrev-ref HEAD))
         (exit_status Unknown)
         (cwd         <REDACTED>)
         (stdout      "")
-        (stderr      <REDACTED>))))
+        (stderr      <REDACTED>)))
      (error <REDACTED>))
     |}];
   abbrev_ref_does_raise "bogus" ~redact_fields:[ "cwd"; "repo_root"; "stderr" ];
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.git ((repo_root <REDACTED>) (args (rev-parse --abbrev-ref bogus))))
        ((prog git)
         (args (rev-parse --abbrev-ref bogus))
         (exit_status (Exited 128))
         (cwd    <REDACTED>)
         (stdout bogus)
-        (stderr <REDACTED>))))
+        (stderr <REDACTED>)))
      (error (Failure "Unexpected error code")))
     |}];
   ()

--- a/example/hello_git_cli.ml
+++ b/example/hello_git_cli.ml
@@ -151,7 +151,7 @@ let%expect_test "hello cli" =
       Vcs.Result.git vcs ~repo_root ~args:[ "rev-parse"; "INVALID-REF" ] ~f:(fun output ->
         if output.exit_code = 0
         then assert false [@coverage off]
-        else Error (Vcs.Err.create_s [%sexp "Hello invalid exit code"]))
+        else Error (Vcs.Err.create_s [%sexp "Hello invalid exit code."]))
     with
     | Ok _ -> assert false
     | Error err ->
@@ -170,7 +170,7 @@ let%expect_test "hello cli" =
         (cwd    <REDACTED>)
         (stdout INVALID-REF)
         (stderr <REDACTED>)))
-     (error "Hello invalid exit code"))
+     (error "Hello invalid exit code."))
     |}];
   let () =
     match
@@ -181,7 +181,7 @@ let%expect_test "hello cli" =
         ~f:(fun output ->
           if output.exit_code = 0
           then assert false [@coverage off]
-          else Error (`Vcs (Vcs.Err.create_s [%sexp "Hello invalid exit code"])))
+          else Error (`Vcs (Vcs.Err.create_s [%sexp "Hello invalid exit code."])))
     with
     | Ok _ -> assert false
     | Error (`Vcs err) ->
@@ -200,7 +200,7 @@ let%expect_test "hello cli" =
         (cwd    <REDACTED>)
         (stdout INVALID-REF)
         (stderr <REDACTED>)))
-     (error "Hello invalid exit code"))
+     (error "Hello invalid exit code."))
     |}];
   (* Here we characterize some unintended ways the API may be abused. *)
   (* 1. [Vcs.git] is meant to be used with a raising helper. In this section we
@@ -239,7 +239,7 @@ let%expect_test "hello cli" =
   (* Another difference is that you do not get the context when the [f] helper
      returns an error. *)
   print_s [%sexp (abbrev_ref "/bogus" : string Or_error.t)];
-  [%expect {| (Error "expected exit code 0") |}];
+  [%expect {| (Error "Expected exit code 0.") |}];
   (* If you are using a non-raising handler [f], you probably meant to use
      [Vcs.Or_error.git]. The type of [abbrev_ref] is the same. *)
   let abbrev_ref ?(repo_root = repo_root) ref_ =
@@ -292,7 +292,7 @@ let%expect_test "hello cli" =
         (cwd    <REDACTED>)
         (stdout bogus)
         (stderr <REDACTED>)))
-     (error "expected exit code 0"))
+     (error "Expected exit code 0."))
     |}];
   (* 2. Let's look now at [Vcs.Or_error.git]. It is meant to be used with a
      non-raising handler [f]. Let's see what happens when [f] raises. *)

--- a/example/hello_vcs_git_unix.ml
+++ b/example/hello_vcs_git_unix.ml
@@ -72,14 +72,14 @@ let%expect_test "hello commit" =
   in
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.git ((repo_root /invalid/path) (args ())))
        ((prog <REDACTED>)
         (args ())
         (exit_status Unknown)
         (cwd         /invalid/path/)
         (stdout      "")
-        (stderr      ""))))
+        (stderr      "")))
      (error ("Unix.Unix_error(Unix.ENOENT, \"open\", \"/invalid/path/\")")))
     |}];
   (* Let's also show a case where the command fails due to a user error. *)
@@ -99,14 +99,14 @@ let%expect_test "hello commit" =
   in
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.git ((repo_root <REDACTED>) (args (rev-parse INVALID-REF))))
        ((prog <REDACTED>)
         (args        (rev-parse INVALID-REF))
         (exit_status (Exited    128))
         (cwd    <REDACTED>)
         (stdout INVALID-REF)
-        (stderr <REDACTED>))))
+        (stderr <REDACTED>)))
      (error "Hello invalid exit code"))
     |}];
   (* Here we only use [Eio] to clean up the temporary repo, because [rmtree] is

--- a/example/hello_vcs_git_unix.ml
+++ b/example/hello_vcs_git_unix.ml
@@ -88,7 +88,7 @@ let%expect_test "hello commit" =
       Vcs.Result.git vcs ~repo_root ~args:[ "rev-parse"; "INVALID-REF" ] ~f:(fun output ->
         if output.exit_code = 0
         then assert false [@coverage off]
-        else Error (Vcs.Err.create_s [%sexp "Hello invalid exit code"]))
+        else Error (Vcs.Err.create_s [%sexp "Hello invalid exit code."]))
     with
     | Ok _ -> assert false
     | Error err ->
@@ -107,7 +107,7 @@ let%expect_test "hello commit" =
         (cwd    <REDACTED>)
         (stdout INVALID-REF)
         (stderr <REDACTED>)))
-     (error "Hello invalid exit code"))
+     (error "Hello invalid exit code."))
     |}];
   (* Here we only use [Eio] to clean up the temporary repo, because [rmtree] is
      a convenient function to use in this test. But the point is that the rest

--- a/lib/vcs/src/err.ml
+++ b/lib/vcs/src/err.ml
@@ -22,18 +22,22 @@
 open! Import
 
 type t =
-  { steps : Sexp.t list
+  { context : Sexp.t list
   ; error : Sexp.t
   }
-[@@deriving sexp_of]
 
-let sexp_of_t ({ steps; error } as t) = if List.is_empty steps then error else sexp_of_t t
+let sexp_of_t { context; error } =
+  if List.is_empty context
+  then error
+  else Sexp.List [ List (Atom "context" :: context); List [ Atom "error"; error ] ]
+;;
+
 let to_string_hum t = t |> sexp_of_t |> Sexp.to_string_hum
-let create_s sexp = { steps = []; error = sexp }
+let create_s sexp = { context = []; error = sexp }
 let error_string str = create_s (Sexp.Atom str)
 let of_exn exn = create_s (sexp_of_exn exn)
-let add_context t ~step = { steps = step :: t.steps; error = t.error }
-let init error ~step = { steps = [ step ]; error }
+let add_context t ~step = { context = step :: t.context; error = t.error }
+let init error ~step = { context = [ step ]; error }
 
 module Private = struct
   module Non_raising_M = struct
@@ -46,7 +50,7 @@ module Private = struct
 
   module View = struct
     type nonrec t = t =
-      { steps : Sexp.t list
+      { context : Sexp.t list
       ; error : Sexp.t
       }
   end

--- a/lib/vcs/src/err.mli
+++ b/lib/vcs/src/err.mli
@@ -61,7 +61,7 @@ module Private : sig
 
   module View : sig
     type t =
-      { steps : Sexp.t list
+      { context : Sexp.t list
       ; error : Sexp.t
       }
   end

--- a/lib/vcs/src/exn0.ml
+++ b/lib/vcs/src/exn0.ml
@@ -23,6 +23,6 @@ exception E of Err.t
 
 let () =
   Sexplib0.Sexp_conv.Exn_converter.add [%extension_constructor E] (function
-    | E err -> Sexp.List [ Atom "Vcs.E"; Err.sexp_of_t err ]
+    | E err -> Err.sexp_of_t err
     | _ -> assert false)
 ;;

--- a/lib/vcs/src/git.ml
+++ b/lib/vcs/src/git.ml
@@ -38,13 +38,13 @@ module Result_impl = struct
   let exit0 { Output.exit_code; stdout = _; stderr = _ } =
     if Int.equal exit_code 0
     then Ok ()
-    else Error (Err.error_string "expected exit code 0")
+    else Error (Err.error_string "Expected exit code 0.")
   ;;
 
   let exit0_and_stdout { Output.exit_code; stdout; stderr = _ } =
     if Int.equal exit_code 0
     then Ok stdout
-    else Error (Err.error_string "expected exit code 0")
+    else Error (Err.error_string "Expected exit code 0.")
   ;;
 
   let exit_code { Output.exit_code; stdout = _; stderr = _ } ~accept =
@@ -54,7 +54,7 @@ module Result_impl = struct
       Error
         (Err.create_s
            [%sexp
-             "unexpected exit code"
+             "Unexpected exit code."
            , { accepted_codes : int list = List.map accept ~f:fst }])
   ;;
 end

--- a/lib/vcs/src/graph.ml
+++ b/lib/vcs/src/graph.ml
@@ -232,7 +232,7 @@ let refs t =
 
 let set_ref t ~rev ~ref_kind =
   match Rev_table.find t.revs rev with
-  | None -> raise (Exn0.E (Err.create_s [%sexp "Rev not found", (rev : Rev.t)]))
+  | None -> raise (Exn0.E (Err.create_s [%sexp "Rev not found.", (rev : Rev.t)]))
   | Some index ->
     (match Ref_kind_table.find t.refs ref_kind with
      | None -> ()
@@ -281,7 +281,7 @@ let add_nodes t ~log =
       | Some node -> node
       | None ->
         raise
-          (Exn0.E (Err.create_s [%sexp "Parent not found", (line : Log.Line.t)]))
+          (Exn0.E (Err.create_s [%sexp "Parent not found.", (line : Log.Line.t)]))
         [@coverage off]
     in
     match (line : Log.Line.t) with
@@ -316,7 +316,7 @@ let add_nodes t ~log =
           (Exn0.E
              (Err.create_s
                 [%sexp
-                  "Node not found during the building of new nodes (internal error)"
+                  "Node not found during the building of new nodes (internal error)."
                 , { rev : Rev.t }])) [@coverage off]
     in
     Queue.to_seq new_nodes
@@ -535,7 +535,7 @@ let check_index_exn t ~index =
     raise
       (Exn0.E
          (Err.create_s
-            [%sexp "Node index out of bounds", { index : int; node_count : int }]))
+            [%sexp "Node index out of bounds.", { index : int; node_count : int }]))
 ;;
 
 let get_node_exn t ~index =

--- a/lib/vcs/test/test__err.ml
+++ b/lib/vcs/test/test__err.ml
@@ -23,7 +23,11 @@ let%expect_test "sexp_of_t" =
   print_s [%sexp (Vcs.Err.create_s [%sexp Hello] : Vcs.Err.t)];
   [%expect {| Hello |}];
   print_s [%sexp (Vcs.Err.init [%sexp Hello] ~step:[%sexp Step] : Vcs.Err.t)];
-  [%expect {| ((steps (Step)) (error Hello)) |}];
+  [%expect
+    {|
+    ((context Step)
+     (error   Hello))
+    |}];
   ()
 ;;
 
@@ -62,15 +66,23 @@ let%expect_test "add_context" =
   [%expect {| Hello |}];
   let err = Vcs.Err.add_context err ~step:[%sexp Step_1] in
   print_s [%sexp (err : Vcs.Err.t)];
-  [%expect {| ((steps (Step_1)) (error Hello)) |}];
+  [%expect
+    {|
+    ((context Step_1)
+     (error   Hello))
+    |}];
   let err = Vcs.Err.add_context err ~step:[%sexp Step_2, { x = 42 }] in
   print_s [%sexp (err : Vcs.Err.t)];
-  [%expect {| ((steps ((Step_2 ((x 42))) Step_1)) (error Hello)) |}];
+  [%expect {| ((context (Step_2 ((x 42))) Step_1) (error Hello)) |}];
   ()
 ;;
 
 let%expect_test "init" =
   print_s [%sexp (Vcs.Err.init [%sexp Hello] ~step:[%sexp Step] : Vcs.Err.t)];
-  [%expect {| ((steps (Step)) (error Hello)) |}];
+  [%expect
+    {|
+    ((context Step)
+     (error   Hello))
+    |}];
   ()
 ;;

--- a/lib/vcs/test/test__exn.ml
+++ b/lib/vcs/test/test__exn.ml
@@ -32,6 +32,10 @@ let%expect_test "reraise_with_context" =
     | _ -> assert false
     | exception Vcs.E err -> print_s [%sexp (err : Vcs.Err.t)]
   in
-  [%expect {| ((steps (Step)) (error Err)) |}];
+  [%expect
+    {|
+    ((context Step)
+     (error   Err))
+    |}];
   ()
 ;;

--- a/lib/vcs/test/test__git.ml
+++ b/lib/vcs/test/test__git.ml
@@ -33,7 +33,7 @@ let%expect_test "exit0" =
      by the code that interprets the result of the user function supplied to
      [Vcs.git]. *)
   test { exit_code = 1; stdout = "stdout"; stderr = "stderr" };
-  [%expect {| (Raised "expected exit code 0") |}];
+  [%expect {| (Raised "Expected exit code 0.") |}];
   ()
 ;;
 
@@ -47,7 +47,7 @@ let%expect_test "exit0_and_stdout" =
   [%expect {| stdout |}];
   (* Same remark as in [exit0] regarding the error trace. *)
   test { exit_code = 1; stdout = "stdout"; stderr = "stderr" };
-  [%expect {| (Raised "expected exit code 0") |}];
+  [%expect {| (Raised "Expected exit code 0.") |}];
   ()
 ;;
 
@@ -63,7 +63,7 @@ let%expect_test "exit_code" =
   [%expect {| (Ok other) |}];
   (* Same remark as in [exit0] regarding the error trace. *)
   test { exit_code = 1; stdout = ""; stderr = "" };
-  [%expect {| (Raised ("unexpected exit code" ((accepted_codes (0 42))))) |}];
+  [%expect {| (Raised ("Unexpected exit code." ((accepted_codes (0 42))))) |}];
   ()
 ;;
 
@@ -77,7 +77,7 @@ let%expect_test "exit0" =
      by the code that interprets the result of the user function supplied to
      [Vcs.Result.git]. *)
   test { exit_code = 1; stdout = "stdout"; stderr = "stderr" };
-  [%expect {| (Error "expected exit code 0") |}];
+  [%expect {| (Error "Expected exit code 0.") |}];
   ()
 ;;
 
@@ -89,7 +89,7 @@ let%expect_test "exit0_and_stdout" =
   [%expect {| (Ok stdout) |}];
   (* Same remark as in [exit0] regarding the error trace. *)
   test { exit_code = 1; stdout = "stdout"; stderr = "stderr" };
-  [%expect {| (Error "expected exit code 0") |}];
+  [%expect {| (Error "Expected exit code 0.") |}];
   ()
 ;;
 
@@ -106,6 +106,6 @@ let%expect_test "exit_code" =
   [%expect {| (Ok other) |}];
   (* Same remark as in [exit0] regarding the error trace. *)
   test { exit_code = 1; stdout = ""; stderr = "" };
-  [%expect {| (Error ("unexpected exit code" ((accepted_codes (0 42))))) |}];
+  [%expect {| (Error ("Unexpected exit code." ((accepted_codes (0 42))))) |}];
   ()
 ;;

--- a/lib/vcs/test/test__graph.ml
+++ b/lib/vcs/test/test__graph.ml
@@ -451,7 +451,7 @@ let%expect_test "set invalid rev" =
       ~ref_kind:(Local_branch { branch_name = Vcs.Branch_name.v "main" })
   in
   require_does_raise [%here] (fun () -> set_ref_r1 ());
-  [%expect {| (Vcs.E ("Rev not found" 5cd237e9598b11065c344d1eb33bc8c15cd237e9)) |}];
+  [%expect {| (Vcs.E ("Rev not found." 5cd237e9598b11065c344d1eb33bc8c15cd237e9)) |}];
   Vcs.Graph.add_nodes graph ~log:[ Root { rev = r1 } ];
   set_ref_r1 ();
   print_s [%sexp (Vcs.Graph.refs graph : Vcs.Refs.t)];
@@ -710,7 +710,7 @@ let%expect_test "debug graph" =
   [%expect
     {|
     (Vcs.E (
-      "Node index out of bounds" (
+      "Node index out of bounds." (
         (index      5)
         (node_count 5))))
     |}];
@@ -718,7 +718,7 @@ let%expect_test "debug graph" =
   [%expect
     {|
     (Vcs.E (
-      "Node index out of bounds" (
+      "Node index out of bounds." (
         (index      -1)
         (node_count 5))))
     |}];

--- a/lib/vcs/test/test__graph.ml
+++ b/lib/vcs/test/test__graph.ml
@@ -451,7 +451,7 @@ let%expect_test "set invalid rev" =
       ~ref_kind:(Local_branch { branch_name = Vcs.Branch_name.v "main" })
   in
   require_does_raise [%here] (fun () -> set_ref_r1 ());
-  [%expect {| (Vcs.E ("Rev not found." 5cd237e9598b11065c344d1eb33bc8c15cd237e9)) |}];
+  [%expect {| ("Rev not found." 5cd237e9598b11065c344d1eb33bc8c15cd237e9) |}];
   Vcs.Graph.add_nodes graph ~log:[ Root { rev = r1 } ];
   set_ref_r1 ();
   print_s [%sexp (Vcs.Graph.refs graph : Vcs.Refs.t)];
@@ -709,18 +709,16 @@ let%expect_test "debug graph" =
   require_does_raise [%here] (fun () -> get_node_exn 5);
   [%expect
     {|
-    (Vcs.E (
-      "Node index out of bounds." (
-        (index      5)
-        (node_count 5))))
+    ("Node index out of bounds." (
+      (index      5)
+      (node_count 5)))
     |}];
   require_does_raise [%here] (fun () -> get_node_exn (-1));
   [%expect
     {|
-    (Vcs.E (
-      "Node index out of bounds." (
-        (index      -1)
-        (node_count 5))))
+    ("Node index out of bounds." (
+      (index      -1)
+      (node_count 5)))
     |}];
   (* Here we monitor for a regression of a bug where [set_ref] would not
      properly update pre-existing bindings. *)

--- a/lib/vcs_base/src/err.ml
+++ b/lib/vcs_base/src/err.ml
@@ -24,8 +24,8 @@ include Vcs.Err
 let to_error t =
   Error.create_s
     (match Private.view t with
-     | { steps = []; error } -> error
-     | { steps = _ :: _; error = _ } -> sexp_of_t t)
+     | { context = []; error } -> error
+     | { context = _ :: _; error = _ } -> sexp_of_t t)
 ;;
 
 let of_error error = create_s (Error.sexp_of_t error)

--- a/lib/vcs_base/test/test__err.ml
+++ b/lib/vcs_base/test/test__err.ml
@@ -26,7 +26,11 @@ let%expect_test "to_error" =
   test (Vcs.Err.create_s [%sexp Hello]);
   [%expect {| Hello |}];
   test (Vcs.Err.init [%sexp Hello] ~step:[%sexp Step]);
-  [%expect {| ((steps (Step)) (error Hello)) |}];
+  [%expect
+    {|
+    ((context Step)
+     (error   Hello))
+    |}];
   ()
 ;;
 

--- a/lib/vcs_base/test/test__git.ml
+++ b/lib/vcs_base/test/test__git.ml
@@ -29,7 +29,7 @@ let%expect_test "exit0" =
      by the code that interprets the result of the user function supplied to
      [Vcs.Or_error.git]. *)
   test { exit_code = 1; stdout = "stdout"; stderr = "stderr" };
-  [%expect {| (Error "expected exit code 0") |}];
+  [%expect {| (Error "Expected exit code 0.") |}];
   ()
 ;;
 
@@ -41,7 +41,7 @@ let%expect_test "exit0_and_stdout" =
   [%expect {| (Ok stdout) |}];
   (* Same remark as in [exit0] regarding the error trace. *)
   test { exit_code = 1; stdout = "stdout"; stderr = "stderr" };
-  [%expect {| (Error "expected exit code 0") |}];
+  [%expect {| (Error "Expected exit code 0.") |}];
   ()
 ;;
 
@@ -58,6 +58,6 @@ let%expect_test "exit_code" =
   [%expect {| (Ok other) |}];
   (* Same remark as in [exit0] regarding the error trace. *)
   test { exit_code = 1; stdout = ""; stderr = "" };
-  [%expect {| (Error ("unexpected exit code" ((accepted_codes (0 42))))) |}];
+  [%expect {| (Error ("Unexpected exit code." ((accepted_codes (0 42))))) |}];
   ()
 ;;

--- a/lib/vcs_cli/src/vcs_cli.ml
+++ b/lib/vcs_cli/src/vcs_cli.ml
@@ -43,7 +43,7 @@ let find_enclosing_repo_root vcs ~from =
       (Vcs.E
          (Vcs.Err.create_s
             [%sexp
-              "Failed to locate enclosing repo root from directory"
+              "Failed to locate enclosing repo root from directory."
             , { from : Absolute_path.t }]))
 ;;
 
@@ -62,7 +62,7 @@ let relativize ~repo_root ~cwd ~path =
   | Some relative_path -> Vcs.Path_in_repo.of_relative_path relative_path
   | None ->
     raise
-      (Vcs.E (Vcs.Err.create_s [%sexp "Path is not in repo", { path : Absolute_path.t }]))
+      (Vcs.E (Vcs.Err.create_s [%sexp "Path is not in repo.", { path : Absolute_path.t }]))
 ;;
 
 open Command.Std
@@ -428,7 +428,7 @@ let branch_revision_cmd =
          raise
            (Vcs.E
               (Vcs.Err.create_s
-                 [%sexp "Branch not found", { branch_name : Vcs.Branch_name.t }]))
+                 [%sexp "Branch not found.", { branch_name : Vcs.Branch_name.t }]))
      in
      print_sexp [%sexp (rev : Vcs.Rev.t)];
      ())
@@ -448,7 +448,7 @@ let descendance_cmd =
        match Vcs.Graph.find_rev graph ~rev with
        | Some node -> node
        | None ->
-         raise (Vcs.E (Vcs.Err.create_s [%sexp "Rev not found", { rev : Vcs.Rev.t }]))
+         raise (Vcs.E (Vcs.Err.create_s [%sexp "Rev not found.", { rev : Vcs.Rev.t }]))
      in
      let node1 = find_node ~rev:rev1 in
      let node2 = find_node ~rev:rev2 in
@@ -473,7 +473,7 @@ let greatest_common_ancestors_cmd =
          match Vcs.Graph.find_rev graph ~rev with
          | Some node -> node
          | None ->
-           raise (Vcs.E (Vcs.Err.create_s [%sexp "Rev not found", { rev : Vcs.Rev.t }])))
+           raise (Vcs.E (Vcs.Err.create_s [%sexp "Rev not found.", { rev : Vcs.Rev.t }])))
      in
      let gca =
        Vcs.Graph.greatest_common_ancestors graph ~nodes

--- a/lib/vcs_git_backend/src/log.ml
+++ b/lib/vcs_git_backend/src/log.ml
@@ -35,7 +35,7 @@ let parse_log_line_exn ~line:str : Vcs.Log.Line.t =
           ; parent2 = Vcs.Rev.v parent2
           }
       | _ :: _ :: _ :: _ ->
-        raise (Vcs.E (Vcs.Err.error_string "Too many words (expected 1, 2, or 3)")))
+        raise (Vcs.E (Vcs.Err.error_string "Too many words (expected 1, 2, or 3).")))
   with
   | Ok t -> t
   | Error err ->

--- a/lib/vcs_git_backend/src/munged_path.ml
+++ b/lib/vcs_git_backend/src/munged_path.ml
@@ -39,13 +39,13 @@ let parse_exn str =
   match
     Vcs.Exn.Private.try_with (fun () ->
       match Astring.String.cuts ~empty:false ~sep:" => " str with
-      | [] -> raise (Vcs.E (Vcs.Err.error_string "Unexpected empty path"))
+      | [] -> raise (Vcs.E (Vcs.Err.error_string "Unexpected empty path."))
       | [ str ] ->
         if
           String.exists str ~f:(function
             | '{' | '}' -> true
             | _ -> false)
-        then raise (Vcs.E (Vcs.Err.error_string "Unexpected '{' or '}' in simple path"))
+        then raise (Vcs.E (Vcs.Err.error_string "Unexpected '{' or '}' in simple path."))
         else One_file (Vcs.Path_in_repo.v str)
       | [ left; right ] ->
         (match String.rsplit2 left ~on:'{' with
@@ -54,20 +54,20 @@ let parse_exn str =
              String.exists str ~f:(function
                | '}' -> true
                | _ -> false)
-           then raise (Vcs.E (Vcs.Err.error_string "Matching '{' not found"))
+           then raise (Vcs.E (Vcs.Err.error_string "Matching '{' not found."))
            else
              Two_files { src = Vcs.Path_in_repo.v left; dst = Vcs.Path_in_repo.v right }
          | Some (prefix, left_of_arrow) ->
            let right_of_arrow, suffix =
              match String.lsplit2 right ~on:'}' with
              | Some split -> split
-             | None -> raise (Vcs.E (Vcs.Err.error_string "Matching '}' not found"))
+             | None -> raise (Vcs.E (Vcs.Err.error_string "Matching '}' not found."))
            in
            Two_files
              { src = Vcs.Path_in_repo.v (prefix ^ left_of_arrow ^ suffix)
              ; dst = Vcs.Path_in_repo.v (prefix ^ right_of_arrow ^ suffix)
              })
-      | _ :: _ :: _ -> raise (Vcs.E (Vcs.Err.error_string "Too many '=>'")))
+      | _ :: _ :: _ -> raise (Vcs.E (Vcs.Err.error_string "Too many ['=>'].")))
   with
   | Ok t -> t
   | Error err ->

--- a/lib/vcs_git_backend/src/name_status.ml
+++ b/lib/vcs_git_backend/src/name_status.ml
@@ -46,7 +46,7 @@ module Diff_status = struct
 
   let parse_exn str : t =
     if String.is_empty str
-    then raise (Vcs.E (Vcs.Err.error_string "Unexpected empty diff status"));
+    then raise (Vcs.E (Vcs.Err.error_string "Unexpected empty diff status."));
     match str.[0] with
     | 'A' -> `A
     | 'D' -> `D
@@ -68,7 +68,7 @@ let parse_line_exn ~line : Vcs.Name_status.Change.t =
     Vcs.Exn.Private.try_with (fun () ->
       match String.split line ~on:'\t' with
       | [] -> assert false
-      | [ _ ] -> raise (Vcs.E (Vcs.Err.error_string "Unexpected output from git status"))
+      | [ _ ] -> raise (Vcs.E (Vcs.Err.error_string "Unexpected output from git status."))
       | status :: path :: rest ->
         (match Diff_status.parse_exn status with
          | `A -> Vcs.Name_status.Change.Added (Vcs.Path_in_repo.v path)
@@ -82,7 +82,7 @@ let parse_line_exn ~line : Vcs.Name_status.Change.t =
              match List.hd rest with
              | Some hd -> Vcs.Path_in_repo.v hd
              | None ->
-               raise (Vcs.E (Vcs.Err.error_string "Unexpected output from git status"))
+               raise (Vcs.E (Vcs.Err.error_string "Unexpected output from git status."))
            in
            (match diff_status with
             | `R -> Renamed { src = Vcs.Path_in_repo.v path; dst = path2; similarity }
@@ -91,7 +91,8 @@ let parse_line_exn ~line : Vcs.Name_status.Change.t =
            raise
              (Vcs.E
                 (Vcs.Err.create_s
-                   [%sexp "Unexpected status", (status : string), (other : Diff_status.t)]))))
+                   [%sexp
+                     "Unexpected status:", (status : string), (other : Diff_status.t)]))))
   with
   | Ok t -> t
   | Error err ->

--- a/lib/vcs_git_backend/src/num_status.ml
+++ b/lib/vcs_git_backend/src/num_status.ml
@@ -49,7 +49,7 @@ let parse_line_exn ~line : Vcs.Num_status.Change.t =
       match String.split line ~on:'\t' with
       | [] -> assert false
       | [ _ ] | [ _; _ ] | _ :: _ :: _ :: _ :: _ ->
-        raise (Vcs.E (Vcs.Err.error_string "Unexpected output from git diff"))
+        raise (Vcs.E (Vcs.Err.error_string "Unexpected output from git diff."))
       | [ insertions; deletions; munged_path ] ->
         { Vcs.Num_status.Change.key = Munged_path.parse_exn munged_path
         ; num_stat =
@@ -62,7 +62,7 @@ let parse_line_exn ~line : Vcs.Num_status.Change.t =
                  (Vcs.E
                     (Vcs.Err.create_s
                        [%sexp
-                         "Unexpected output from git diff"
+                         "Unexpected output from git diff."
                        , { insertions : Status_code.t; deletions : Status_code.t }])))
         })
   with

--- a/lib/vcs_git_backend/src/refs.ml
+++ b/lib/vcs_git_backend/src/refs.ml
@@ -28,7 +28,7 @@ let parse_ref_kind_exn str : Vcs.Ref_kind.t =
         match String.chop_prefix str ~prefix:"refs/" with
         | Some str -> str
         | None ->
-          raise (Vcs.E (Vcs.Err.error_string "Expected ref to start with 'refs/'"))
+          raise (Vcs.E (Vcs.Err.error_string "Expected ref to start with ['refs/']."))
       in
       match String.lsplit2 str ~on:'/' with
       | None -> Vcs.Ref_kind.Other { name = str }
@@ -80,7 +80,7 @@ module Dereferenced = struct
     match
       Vcs.Exn.Private.try_with (fun () ->
         match String.lsplit2 str ~on:' ' with
-        | None -> raise (Vcs.E (Vcs.Err.error_string "Invalid ref line"))
+        | None -> raise (Vcs.E (Vcs.Err.error_string "Invalid ref line."))
         | Some (rev, ref_) ->
           (match String.chop_suffix ref_ ~suffix:"^{}" with
            | Some ref_ ->

--- a/lib/vcs_git_backend/test/test__log.ml
+++ b/lib/vcs_git_backend/test/test__log.ml
@@ -95,7 +95,7 @@ let%expect_test "invalid lines" =
         Vcs_git_backend.Log.parse_log_line_exn ((
           line
           "3bf5092cc55bff4c3ba546c771e17ab8d29cce65 aff8c9c8601e68a41a3bb695ea4a276e2446061f d3a24cbfad0a681280ecfe021d40b69fb0b9c589 3509268b3f47a9e081bf11ac5e59f8b6eac6109b"))))
-      (error "Too many words (expected 1, 2, or 3)")))
+      (error "Too many words (expected 1, 2, or 3).")))
     |}];
   ()
 ;;

--- a/lib/vcs_git_backend/test/test__log.ml
+++ b/lib/vcs_git_backend/test/test__log.ml
@@ -80,9 +80,8 @@ let%expect_test "invalid lines" =
   require_does_raise [%here] (fun () -> test "");
   [%expect
     {|
-    (Vcs.E (
-      (context (Vcs_git_backend.Log.parse_log_line_exn ((line ""))))
-      (error (Invalid_argument "\"\": invalid rev"))))
+    ((context (Vcs_git_backend.Log.parse_log_line_exn ((line ""))))
+     (error (Invalid_argument "\"\": invalid rev")))
     |}];
   require_does_raise [%here] (fun () ->
     test
@@ -90,12 +89,11 @@ let%expect_test "invalid lines" =
        d3a24cbfad0a681280ecfe021d40b69fb0b9c589 3509268b3f47a9e081bf11ac5e59f8b6eac6109b");
   [%expect
     {|
-    (Vcs.E (
-      (context (
-        Vcs_git_backend.Log.parse_log_line_exn ((
-          line
-          "3bf5092cc55bff4c3ba546c771e17ab8d29cce65 aff8c9c8601e68a41a3bb695ea4a276e2446061f d3a24cbfad0a681280ecfe021d40b69fb0b9c589 3509268b3f47a9e081bf11ac5e59f8b6eac6109b"))))
-      (error "Too many words (expected 1, 2, or 3).")))
+    ((context (
+       Vcs_git_backend.Log.parse_log_line_exn ((
+         line
+         "3bf5092cc55bff4c3ba546c771e17ab8d29cce65 aff8c9c8601e68a41a3bb695ea4a276e2446061f d3a24cbfad0a681280ecfe021d40b69fb0b9c589 3509268b3f47a9e081bf11ac5e59f8b6eac6109b"))))
+     (error "Too many words (expected 1, 2, or 3)."))
     |}];
   ()
 ;;

--- a/lib/vcs_git_backend/test/test__log.ml
+++ b/lib/vcs_git_backend/test/test__log.ml
@@ -81,7 +81,7 @@ let%expect_test "invalid lines" =
   [%expect
     {|
     (Vcs.E (
-      (steps ((Vcs_git_backend.Log.parse_log_line_exn ((line "")))))
+      (context (Vcs_git_backend.Log.parse_log_line_exn ((line ""))))
       (error (Invalid_argument "\"\": invalid rev"))))
     |}];
   require_does_raise [%here] (fun () ->
@@ -91,10 +91,10 @@ let%expect_test "invalid lines" =
   [%expect
     {|
     (Vcs.E (
-      (steps ((
+      (context (
         Vcs_git_backend.Log.parse_log_line_exn ((
           line
-          "3bf5092cc55bff4c3ba546c771e17ab8d29cce65 aff8c9c8601e68a41a3bb695ea4a276e2446061f d3a24cbfad0a681280ecfe021d40b69fb0b9c589 3509268b3f47a9e081bf11ac5e59f8b6eac6109b")))))
+          "3bf5092cc55bff4c3ba546c771e17ab8d29cce65 aff8c9c8601e68a41a3bb695ea4a276e2446061f d3a24cbfad0a681280ecfe021d40b69fb0b9c589 3509268b3f47a9e081bf11ac5e59f8b6eac6109b"))))
       (error "Too many words (expected 1, 2, or 3)")))
     |}];
   ()

--- a/lib/vcs_git_backend/test/test__munged_path.ml
+++ b/lib/vcs_git_backend/test/test__munged_path.ml
@@ -28,7 +28,7 @@ let%expect_test "parse" =
     {|
     (Vcs.E (
       (context (Vcs_git_backend.Munged_path.parse_exn ((path ""))))
-      (error "Unexpected empty path")))
+      (error "Unexpected empty path.")))
     |}];
   require_does_raise [%here] (fun () -> test "/tmp => /tmp");
   [%expect
@@ -43,35 +43,35 @@ let%expect_test "parse" =
     (Vcs.E (
       (context (
         Vcs_git_backend.Munged_path.parse_exn ((path "tmp => tmp2 => tmp3"))))
-      (error "Too many '=>'")))
+      (error "Too many ['=>'].")))
     |}];
   require_does_raise [%here] (fun () -> test "}");
   [%expect
     {|
     (Vcs.E (
       (context (Vcs_git_backend.Munged_path.parse_exn ((path }))))
-      (error "Unexpected '{' or '}' in simple path")))
+      (error "Unexpected '{' or '}' in simple path.")))
     |}];
   require_does_raise [%here] (fun () -> test "{");
   [%expect
     {|
     (Vcs.E (
       (context (Vcs_git_backend.Munged_path.parse_exn ((path {))))
-      (error "Unexpected '{' or '}' in simple path")))
+      (error "Unexpected '{' or '}' in simple path.")))
     |}];
   require_does_raise [%here] (fun () -> test "a/{dir => b");
   [%expect
     {|
     (Vcs.E (
       (context (Vcs_git_backend.Munged_path.parse_exn ((path "a/{dir => b"))))
-      (error "Matching '}' not found")))
+      (error "Matching '}' not found.")))
     |}];
   require_does_raise [%here] (fun () -> test "a/dir => b}");
   [%expect
     {|
     (Vcs.E (
       (context (Vcs_git_backend.Munged_path.parse_exn ((path "a/dir => b}"))))
-      (error "Matching '{' not found")))
+      (error "Matching '{' not found.")))
     |}];
   test "a/simple/path";
   [%expect {| (One_file a/simple/path) |}];

--- a/lib/vcs_git_backend/test/test__munged_path.ml
+++ b/lib/vcs_git_backend/test/test__munged_path.ml
@@ -27,50 +27,50 @@ let%expect_test "parse" =
   [%expect
     {|
     (Vcs.E (
-      (steps ((Vcs_git_backend.Munged_path.parse_exn ((path "")))))
+      (context (Vcs_git_backend.Munged_path.parse_exn ((path ""))))
       (error "Unexpected empty path")))
     |}];
   require_does_raise [%here] (fun () -> test "/tmp => /tmp");
   [%expect
     {|
     (Vcs.E (
-      (steps ((Vcs_git_backend.Munged_path.parse_exn ((path "/tmp => /tmp")))))
+      (context (Vcs_git_backend.Munged_path.parse_exn ((path "/tmp => /tmp"))))
       (error (Invalid_argument "\"/tmp\": not a relative path"))))
     |}];
   require_does_raise [%here] (fun () -> test "tmp => tmp2 => tmp3");
   [%expect
     {|
     (Vcs.E (
-      (steps ((
-        Vcs_git_backend.Munged_path.parse_exn ((path "tmp => tmp2 => tmp3")))))
+      (context (
+        Vcs_git_backend.Munged_path.parse_exn ((path "tmp => tmp2 => tmp3"))))
       (error "Too many '=>'")))
     |}];
   require_does_raise [%here] (fun () -> test "}");
   [%expect
     {|
     (Vcs.E (
-      (steps ((Vcs_git_backend.Munged_path.parse_exn ((path })))))
+      (context (Vcs_git_backend.Munged_path.parse_exn ((path }))))
       (error "Unexpected '{' or '}' in simple path")))
     |}];
   require_does_raise [%here] (fun () -> test "{");
   [%expect
     {|
     (Vcs.E (
-      (steps ((Vcs_git_backend.Munged_path.parse_exn ((path {)))))
+      (context (Vcs_git_backend.Munged_path.parse_exn ((path {))))
       (error "Unexpected '{' or '}' in simple path")))
     |}];
   require_does_raise [%here] (fun () -> test "a/{dir => b");
   [%expect
     {|
     (Vcs.E (
-      (steps ((Vcs_git_backend.Munged_path.parse_exn ((path "a/{dir => b")))))
+      (context (Vcs_git_backend.Munged_path.parse_exn ((path "a/{dir => b"))))
       (error "Matching '}' not found")))
     |}];
   require_does_raise [%here] (fun () -> test "a/dir => b}");
   [%expect
     {|
     (Vcs.E (
-      (steps ((Vcs_git_backend.Munged_path.parse_exn ((path "a/dir => b}")))))
+      (context (Vcs_git_backend.Munged_path.parse_exn ((path "a/dir => b}"))))
       (error "Matching '{' not found")))
     |}];
   test "a/simple/path";

--- a/lib/vcs_git_backend/test/test__munged_path.ml
+++ b/lib/vcs_git_backend/test/test__munged_path.ml
@@ -26,52 +26,45 @@ let%expect_test "parse" =
   require_does_raise [%here] (fun () -> test "");
   [%expect
     {|
-    (Vcs.E (
-      (context (Vcs_git_backend.Munged_path.parse_exn ((path ""))))
-      (error "Unexpected empty path.")))
+    ((context (Vcs_git_backend.Munged_path.parse_exn ((path ""))))
+     (error "Unexpected empty path."))
     |}];
   require_does_raise [%here] (fun () -> test "/tmp => /tmp");
   [%expect
     {|
-    (Vcs.E (
-      (context (Vcs_git_backend.Munged_path.parse_exn ((path "/tmp => /tmp"))))
-      (error (Invalid_argument "\"/tmp\": not a relative path"))))
+    ((context (Vcs_git_backend.Munged_path.parse_exn ((path "/tmp => /tmp"))))
+     (error (Invalid_argument "\"/tmp\": not a relative path")))
     |}];
   require_does_raise [%here] (fun () -> test "tmp => tmp2 => tmp3");
   [%expect
     {|
-    (Vcs.E (
-      (context (
-        Vcs_git_backend.Munged_path.parse_exn ((path "tmp => tmp2 => tmp3"))))
-      (error "Too many ['=>'].")))
+    ((context (
+       Vcs_git_backend.Munged_path.parse_exn ((path "tmp => tmp2 => tmp3"))))
+     (error "Too many ['=>']."))
     |}];
   require_does_raise [%here] (fun () -> test "}");
   [%expect
     {|
-    (Vcs.E (
-      (context (Vcs_git_backend.Munged_path.parse_exn ((path }))))
-      (error "Unexpected '{' or '}' in simple path.")))
+    ((context (Vcs_git_backend.Munged_path.parse_exn ((path }))))
+     (error "Unexpected '{' or '}' in simple path."))
     |}];
   require_does_raise [%here] (fun () -> test "{");
   [%expect
     {|
-    (Vcs.E (
-      (context (Vcs_git_backend.Munged_path.parse_exn ((path {))))
-      (error "Unexpected '{' or '}' in simple path.")))
+    ((context (Vcs_git_backend.Munged_path.parse_exn ((path {))))
+     (error "Unexpected '{' or '}' in simple path."))
     |}];
   require_does_raise [%here] (fun () -> test "a/{dir => b");
   [%expect
     {|
-    (Vcs.E (
-      (context (Vcs_git_backend.Munged_path.parse_exn ((path "a/{dir => b"))))
-      (error "Matching '}' not found.")))
+    ((context (Vcs_git_backend.Munged_path.parse_exn ((path "a/{dir => b"))))
+     (error "Matching '}' not found."))
     |}];
   require_does_raise [%here] (fun () -> test "a/dir => b}");
   [%expect
     {|
-    (Vcs.E (
-      (context (Vcs_git_backend.Munged_path.parse_exn ((path "a/dir => b}"))))
-      (error "Matching '{' not found.")))
+    ((context (Vcs_git_backend.Munged_path.parse_exn ((path "a/dir => b}"))))
+     (error "Matching '{' not found."))
     |}];
   test "a/simple/path";
   [%expect {| (One_file a/simple/path) |}];

--- a/lib/vcs_git_backend/test/test__name_status.ml
+++ b/lib/vcs_git_backend/test/test__name_status.ml
@@ -226,12 +226,12 @@ let%expect_test "parse_lines_exn" =
     ("" (
       Error (
         Vcs.E (
-          (steps ((Vcs_git_backend.Name_status.parse_line_exn ((line "")))))
+          (context (Vcs_git_backend.Name_status.parse_line_exn ((line ""))))
           (error "Unexpected output from git status")))))
     (file (
       Error (
         Vcs.E (
-          (steps ((Vcs_git_backend.Name_status.parse_line_exn ((line file)))))
+          (context (Vcs_git_backend.Name_status.parse_line_exn ((line file))))
           (error "Unexpected output from git status")))))
     ("A\tfile1" (Ok (Added file1)))
     ("D\tfile2" (Ok (Removed file2)))
@@ -239,44 +239,50 @@ let%expect_test "parse_lines_exn" =
     ("U\tfile4" (
       Error (
         Vcs.E (
-          (steps ((Vcs_git_backend.Name_status.parse_line_exn ((line "U\tfile4")))))
+          (context (
+            Vcs_git_backend.Name_status.parse_line_exn ((line "U\tfile4"))))
           (error ("Unexpected status" U U))))))
     ("Q\tfile5" (
       Error (
         Vcs.E (
-          (steps ((Vcs_git_backend.Name_status.parse_line_exn ((line "Q\tfile5")))))
+          (context (
+            Vcs_git_backend.Name_status.parse_line_exn ((line "Q\tfile5"))))
           (error ("Unexpected status" Q Q))))))
     ("I\tfile6" (
       Error (
         Vcs.E (
-          (steps ((Vcs_git_backend.Name_status.parse_line_exn ((line "I\tfile6")))))
+          (context (
+            Vcs_git_backend.Name_status.parse_line_exn ((line "I\tfile6"))))
           (error ("Unexpected status" I I))))))
     ("?\tfile7" (
       Error (
         Vcs.E (
-          (steps ((Vcs_git_backend.Name_status.parse_line_exn ((line "?\tfile7")))))
+          (context (
+            Vcs_git_backend.Name_status.parse_line_exn ((line "?\tfile7"))))
           (error ("Unexpected status" ? Question_mark))))))
     ("!\tfile8" (
       Error (
         Vcs.E (
-          (steps ((Vcs_git_backend.Name_status.parse_line_exn ((line "!\tfile8")))))
+          (context (
+            Vcs_git_backend.Name_status.parse_line_exn ((line "!\tfile8"))))
           (error ("Unexpected status" ! Bang))))))
     ("X\tfile9" (
       Error (
         Vcs.E (
-          (steps ((Vcs_git_backend.Name_status.parse_line_exn ((line "X\tfile9")))))
+          (context (
+            Vcs_git_backend.Name_status.parse_line_exn ((line "X\tfile9"))))
           (error ("Unexpected status" X X))))))
     ("R\tfile10" (
       Error (
         Vcs.E (
-          (steps ((
-            Vcs_git_backend.Name_status.parse_line_exn ((line "R\tfile10")))))
+          (context (
+            Vcs_git_backend.Name_status.parse_line_exn ((line "R\tfile10"))))
           (error (Failure "Int.of_string: \"\""))))))
     ("R35\tfile10" (
       Error (
         Vcs.E (
-          (steps ((
-            Vcs_git_backend.Name_status.parse_line_exn ((line "R35\tfile10")))))
+          (context (
+            Vcs_git_backend.Name_status.parse_line_exn ((line "R35\tfile10"))))
           (error "Unexpected output from git status")))))
     ("R35\tfile1\tfile2" (
       Ok (
@@ -287,8 +293,8 @@ let%expect_test "parse_lines_exn" =
     ("C\tfile11" (
       Error (
         Vcs.E (
-          (steps ((
-            Vcs_git_backend.Name_status.parse_line_exn ((line "C\tfile11")))))
+          (context (
+            Vcs_git_backend.Name_status.parse_line_exn ((line "C\tfile11"))))
           (error (Failure "Int.of_string: \"\""))))))
     ("C75\tfile1\tfile2" (
       Ok (
@@ -299,8 +305,8 @@ let%expect_test "parse_lines_exn" =
     ("Z\tfile12" (
       Error (
         Vcs.E (
-          (steps ((
-            Vcs_git_backend.Name_status.parse_line_exn ((line "Z\tfile12")))))
+          (context (
+            Vcs_git_backend.Name_status.parse_line_exn ((line "Z\tfile12"))))
           (error ("Unexpected status" Z Not_supported))))))
     |}];
   ()

--- a/lib/vcs_git_backend/test/test__name_status.ml
+++ b/lib/vcs_git_backend/test/test__name_status.ml
@@ -191,7 +191,7 @@ let%expect_test "Diff_status" =
     (Z Not_supported) |}];
   require_does_raise [%here] (fun () ->
     Vcs_git_backend.Name_status.Diff_status.parse_exn "");
-  [%expect {| (Vcs.E "Unexpected empty diff status.") |}];
+  [%expect {| "Unexpected empty diff status." |}];
   ()
 ;;
 
@@ -225,65 +225,48 @@ let%expect_test "parse_lines_exn" =
     {|
     ("" (
       Error (
-        Vcs.E (
-          (context (Vcs_git_backend.Name_status.parse_line_exn ((line ""))))
-          (error "Unexpected output from git status.")))))
+        (context (Vcs_git_backend.Name_status.parse_line_exn ((line ""))))
+        (error "Unexpected output from git status."))))
     (file (
       Error (
-        Vcs.E (
-          (context (Vcs_git_backend.Name_status.parse_line_exn ((line file))))
-          (error "Unexpected output from git status.")))))
+        (context (Vcs_git_backend.Name_status.parse_line_exn ((line file))))
+        (error "Unexpected output from git status."))))
     ("A\tfile1" (Ok (Added file1)))
     ("D\tfile2" (Ok (Removed file2)))
     ("M\tfile3" (Ok (Modified file3)))
     ("U\tfile4" (
       Error (
-        Vcs.E (
-          (context (
-            Vcs_git_backend.Name_status.parse_line_exn ((line "U\tfile4"))))
-          (error ("Unexpected status:" U U))))))
+        (context (Vcs_git_backend.Name_status.parse_line_exn ((line "U\tfile4"))))
+        (error ("Unexpected status:" U U)))))
     ("Q\tfile5" (
       Error (
-        Vcs.E (
-          (context (
-            Vcs_git_backend.Name_status.parse_line_exn ((line "Q\tfile5"))))
-          (error ("Unexpected status:" Q Q))))))
+        (context (Vcs_git_backend.Name_status.parse_line_exn ((line "Q\tfile5"))))
+        (error ("Unexpected status:" Q Q)))))
     ("I\tfile6" (
       Error (
-        Vcs.E (
-          (context (
-            Vcs_git_backend.Name_status.parse_line_exn ((line "I\tfile6"))))
-          (error ("Unexpected status:" I I))))))
+        (context (Vcs_git_backend.Name_status.parse_line_exn ((line "I\tfile6"))))
+        (error ("Unexpected status:" I I)))))
     ("?\tfile7" (
       Error (
-        Vcs.E (
-          (context (
-            Vcs_git_backend.Name_status.parse_line_exn ((line "?\tfile7"))))
-          (error ("Unexpected status:" ? Question_mark))))))
+        (context (Vcs_git_backend.Name_status.parse_line_exn ((line "?\tfile7"))))
+        (error ("Unexpected status:" ? Question_mark)))))
     ("!\tfile8" (
       Error (
-        Vcs.E (
-          (context (
-            Vcs_git_backend.Name_status.parse_line_exn ((line "!\tfile8"))))
-          (error ("Unexpected status:" ! Bang))))))
+        (context (Vcs_git_backend.Name_status.parse_line_exn ((line "!\tfile8"))))
+        (error ("Unexpected status:" ! Bang)))))
     ("X\tfile9" (
       Error (
-        Vcs.E (
-          (context (
-            Vcs_git_backend.Name_status.parse_line_exn ((line "X\tfile9"))))
-          (error ("Unexpected status:" X X))))))
+        (context (Vcs_git_backend.Name_status.parse_line_exn ((line "X\tfile9"))))
+        (error ("Unexpected status:" X X)))))
     ("R\tfile10" (
       Error (
-        Vcs.E (
-          (context (
-            Vcs_git_backend.Name_status.parse_line_exn ((line "R\tfile10"))))
-          (error (Failure "Int.of_string: \"\""))))))
+        (context (Vcs_git_backend.Name_status.parse_line_exn ((line "R\tfile10"))))
+        (error (Failure "Int.of_string: \"\"")))))
     ("R35\tfile10" (
       Error (
-        Vcs.E (
-          (context (
-            Vcs_git_backend.Name_status.parse_line_exn ((line "R35\tfile10"))))
-          (error "Unexpected output from git status.")))))
+        (context (
+          Vcs_git_backend.Name_status.parse_line_exn ((line "R35\tfile10"))))
+        (error "Unexpected output from git status."))))
     ("R35\tfile1\tfile2" (
       Ok (
         Renamed
@@ -292,10 +275,8 @@ let%expect_test "parse_lines_exn" =
         (similarity 35))))
     ("C\tfile11" (
       Error (
-        Vcs.E (
-          (context (
-            Vcs_git_backend.Name_status.parse_line_exn ((line "C\tfile11"))))
-          (error (Failure "Int.of_string: \"\""))))))
+        (context (Vcs_git_backend.Name_status.parse_line_exn ((line "C\tfile11"))))
+        (error (Failure "Int.of_string: \"\"")))))
     ("C75\tfile1\tfile2" (
       Ok (
         Copied
@@ -304,10 +285,8 @@ let%expect_test "parse_lines_exn" =
         (similarity 75))))
     ("Z\tfile12" (
       Error (
-        Vcs.E (
-          (context (
-            Vcs_git_backend.Name_status.parse_line_exn ((line "Z\tfile12"))))
-          (error ("Unexpected status:" Z Not_supported))))))
+        (context (Vcs_git_backend.Name_status.parse_line_exn ((line "Z\tfile12"))))
+        (error ("Unexpected status:" Z Not_supported)))))
     |}];
   ()
 ;;

--- a/lib/vcs_git_backend/test/test__name_status.ml
+++ b/lib/vcs_git_backend/test/test__name_status.ml
@@ -191,7 +191,7 @@ let%expect_test "Diff_status" =
     (Z Not_supported) |}];
   require_does_raise [%here] (fun () ->
     Vcs_git_backend.Name_status.Diff_status.parse_exn "");
-  [%expect {| (Vcs.E "Unexpected empty diff status") |}];
+  [%expect {| (Vcs.E "Unexpected empty diff status.") |}];
   ()
 ;;
 
@@ -227,12 +227,12 @@ let%expect_test "parse_lines_exn" =
       Error (
         Vcs.E (
           (context (Vcs_git_backend.Name_status.parse_line_exn ((line ""))))
-          (error "Unexpected output from git status")))))
+          (error "Unexpected output from git status.")))))
     (file (
       Error (
         Vcs.E (
           (context (Vcs_git_backend.Name_status.parse_line_exn ((line file))))
-          (error "Unexpected output from git status")))))
+          (error "Unexpected output from git status.")))))
     ("A\tfile1" (Ok (Added file1)))
     ("D\tfile2" (Ok (Removed file2)))
     ("M\tfile3" (Ok (Modified file3)))
@@ -241,37 +241,37 @@ let%expect_test "parse_lines_exn" =
         Vcs.E (
           (context (
             Vcs_git_backend.Name_status.parse_line_exn ((line "U\tfile4"))))
-          (error ("Unexpected status" U U))))))
+          (error ("Unexpected status:" U U))))))
     ("Q\tfile5" (
       Error (
         Vcs.E (
           (context (
             Vcs_git_backend.Name_status.parse_line_exn ((line "Q\tfile5"))))
-          (error ("Unexpected status" Q Q))))))
+          (error ("Unexpected status:" Q Q))))))
     ("I\tfile6" (
       Error (
         Vcs.E (
           (context (
             Vcs_git_backend.Name_status.parse_line_exn ((line "I\tfile6"))))
-          (error ("Unexpected status" I I))))))
+          (error ("Unexpected status:" I I))))))
     ("?\tfile7" (
       Error (
         Vcs.E (
           (context (
             Vcs_git_backend.Name_status.parse_line_exn ((line "?\tfile7"))))
-          (error ("Unexpected status" ? Question_mark))))))
+          (error ("Unexpected status:" ? Question_mark))))))
     ("!\tfile8" (
       Error (
         Vcs.E (
           (context (
             Vcs_git_backend.Name_status.parse_line_exn ((line "!\tfile8"))))
-          (error ("Unexpected status" ! Bang))))))
+          (error ("Unexpected status:" ! Bang))))))
     ("X\tfile9" (
       Error (
         Vcs.E (
           (context (
             Vcs_git_backend.Name_status.parse_line_exn ((line "X\tfile9"))))
-          (error ("Unexpected status" X X))))))
+          (error ("Unexpected status:" X X))))))
     ("R\tfile10" (
       Error (
         Vcs.E (
@@ -283,7 +283,7 @@ let%expect_test "parse_lines_exn" =
         Vcs.E (
           (context (
             Vcs_git_backend.Name_status.parse_line_exn ((line "R35\tfile10"))))
-          (error "Unexpected output from git status")))))
+          (error "Unexpected output from git status.")))))
     ("R35\tfile1\tfile2" (
       Ok (
         Renamed
@@ -307,7 +307,7 @@ let%expect_test "parse_lines_exn" =
         Vcs.E (
           (context (
             Vcs_git_backend.Name_status.parse_line_exn ((line "Z\tfile12"))))
-          (error ("Unexpected status" Z Not_supported))))))
+          (error ("Unexpected status:" Z Not_supported))))))
     |}];
   ()
 ;;

--- a/lib/vcs_git_backend/test/test__num_status.ml
+++ b/lib/vcs_git_backend/test/test__num_status.ml
@@ -481,28 +481,28 @@ let%expect_test "parse_lines_exn" =
     ("" (
       Error (
         Vcs.E (
-          (steps ((Vcs_git_backend.Num_status.parse_line_exn ((line "")))))
+          (context (Vcs_git_backend.Num_status.parse_line_exn ((line ""))))
           (error "Unexpected output from git diff")))))
     (file (
       Error (
         Vcs.E (
-          (steps ((Vcs_git_backend.Num_status.parse_line_exn ((line file)))))
+          (context (Vcs_git_backend.Num_status.parse_line_exn ((line file))))
           (error "Unexpected output from git diff")))))
     ("A\tB" (
       Error (
         Vcs.E (
-          (steps ((Vcs_git_backend.Num_status.parse_line_exn ((line "A\tB")))))
+          (context (Vcs_git_backend.Num_status.parse_line_exn ((line "A\tB"))))
           (error "Unexpected output from git diff")))))
     ("A\tB\tC\tD" (
       Error (
         Vcs.E (
-          (steps ((
-            Vcs_git_backend.Num_status.parse_line_exn ((line "A\tB\tC\tD")))))
+          (context (
+            Vcs_git_backend.Num_status.parse_line_exn ((line "A\tB\tC\tD"))))
           (error "Unexpected output from git diff")))))
     ("A\tB\tC" (
       Error (
         Vcs.E (
-          (steps ((Vcs_git_backend.Num_status.parse_line_exn ((line "A\tB\tC")))))
+          (context (Vcs_git_backend.Num_status.parse_line_exn ((line "A\tB\tC"))))
           (error (
             "Unexpected output from git diff" (
               (insertions (Other A))
@@ -538,24 +538,24 @@ let%expect_test "parse_lines_exn" =
     ("-\t10\tfile" (
       Error (
         Vcs.E (
-          (steps ((
-            Vcs_git_backend.Num_status.parse_line_exn ((line "-\t10\tfile")))))
+          (context (
+            Vcs_git_backend.Num_status.parse_line_exn ((line "-\t10\tfile"))))
           (error (
             "Unexpected output from git diff" (
               (insertions Dash) (deletions (Num 10)))))))))
     ("7\t-\tfile" (
       Error (
         Vcs.E (
-          (steps ((
-            Vcs_git_backend.Num_status.parse_line_exn ((line "7\t-\tfile")))))
+          (context (
+            Vcs_git_backend.Num_status.parse_line_exn ((line "7\t-\tfile"))))
           (error (
             "Unexpected output from git diff" (
               (insertions (Num 7)) (deletions Dash))))))))
     ("-2\t-10\tfile" (
       Error (
         Vcs.E (
-          (steps ((
-            Vcs_git_backend.Num_status.parse_line_exn ((line "-2\t-10\tfile")))))
+          (context (
+            Vcs_git_backend.Num_status.parse_line_exn ((line "-2\t-10\tfile"))))
           (error (
             "Unexpected output from git diff" (
               (insertions (Other -2))
@@ -563,10 +563,10 @@ let%expect_test "parse_lines_exn" =
     ("1985\t0\tfile1 => /tmp/file2" (
       Error (
         Vcs.E (
-          (steps (
+          (context
             (Vcs_git_backend.Num_status.parse_line_exn
              ((line "1985\t0\tfile1 => /tmp/file2")))
-            (Vcs_git_backend.Munged_path.parse_exn ((path "file1 => /tmp/file2")))))
+            (Vcs_git_backend.Munged_path.parse_exn ((path "file1 => /tmp/file2"))))
           (error (Invalid_argument "\"/tmp/file2\": not a relative path"))))))
     |}];
   ()

--- a/lib/vcs_git_backend/test/test__num_status.ml
+++ b/lib/vcs_git_backend/test/test__num_status.ml
@@ -482,29 +482,29 @@ let%expect_test "parse_lines_exn" =
       Error (
         Vcs.E (
           (context (Vcs_git_backend.Num_status.parse_line_exn ((line ""))))
-          (error "Unexpected output from git diff")))))
+          (error "Unexpected output from git diff.")))))
     (file (
       Error (
         Vcs.E (
           (context (Vcs_git_backend.Num_status.parse_line_exn ((line file))))
-          (error "Unexpected output from git diff")))))
+          (error "Unexpected output from git diff.")))))
     ("A\tB" (
       Error (
         Vcs.E (
           (context (Vcs_git_backend.Num_status.parse_line_exn ((line "A\tB"))))
-          (error "Unexpected output from git diff")))))
+          (error "Unexpected output from git diff.")))))
     ("A\tB\tC\tD" (
       Error (
         Vcs.E (
           (context (
             Vcs_git_backend.Num_status.parse_line_exn ((line "A\tB\tC\tD"))))
-          (error "Unexpected output from git diff")))))
+          (error "Unexpected output from git diff.")))))
     ("A\tB\tC" (
       Error (
         Vcs.E (
           (context (Vcs_git_backend.Num_status.parse_line_exn ((line "A\tB\tC"))))
           (error (
-            "Unexpected output from git diff" (
+            "Unexpected output from git diff." (
               (insertions (Other A))
               (deletions  (Other B)))))))))
     ("0\t1\tfile" (
@@ -541,7 +541,7 @@ let%expect_test "parse_lines_exn" =
           (context (
             Vcs_git_backend.Num_status.parse_line_exn ((line "-\t10\tfile"))))
           (error (
-            "Unexpected output from git diff" (
+            "Unexpected output from git diff." (
               (insertions Dash) (deletions (Num 10)))))))))
     ("7\t-\tfile" (
       Error (
@@ -549,7 +549,7 @@ let%expect_test "parse_lines_exn" =
           (context (
             Vcs_git_backend.Num_status.parse_line_exn ((line "7\t-\tfile"))))
           (error (
-            "Unexpected output from git diff" (
+            "Unexpected output from git diff." (
               (insertions (Num 7)) (deletions Dash))))))))
     ("-2\t-10\tfile" (
       Error (
@@ -557,7 +557,7 @@ let%expect_test "parse_lines_exn" =
           (context (
             Vcs_git_backend.Num_status.parse_line_exn ((line "-2\t-10\tfile"))))
           (error (
-            "Unexpected output from git diff" (
+            "Unexpected output from git diff." (
               (insertions (Other -2))
               (deletions  (Other -10)))))))))
     ("1985\t0\tfile1 => /tmp/file2" (

--- a/lib/vcs_git_backend/test/test__num_status.ml
+++ b/lib/vcs_git_backend/test/test__num_status.ml
@@ -480,33 +480,27 @@ let%expect_test "parse_lines_exn" =
     {|
     ("" (
       Error (
-        Vcs.E (
-          (context (Vcs_git_backend.Num_status.parse_line_exn ((line ""))))
-          (error "Unexpected output from git diff.")))))
+        (context (Vcs_git_backend.Num_status.parse_line_exn ((line ""))))
+        (error "Unexpected output from git diff."))))
     (file (
       Error (
-        Vcs.E (
-          (context (Vcs_git_backend.Num_status.parse_line_exn ((line file))))
-          (error "Unexpected output from git diff.")))))
+        (context (Vcs_git_backend.Num_status.parse_line_exn ((line file))))
+        (error "Unexpected output from git diff."))))
     ("A\tB" (
       Error (
-        Vcs.E (
-          (context (Vcs_git_backend.Num_status.parse_line_exn ((line "A\tB"))))
-          (error "Unexpected output from git diff.")))))
+        (context (Vcs_git_backend.Num_status.parse_line_exn ((line "A\tB"))))
+        (error "Unexpected output from git diff."))))
     ("A\tB\tC\tD" (
       Error (
-        Vcs.E (
-          (context (
-            Vcs_git_backend.Num_status.parse_line_exn ((line "A\tB\tC\tD"))))
-          (error "Unexpected output from git diff.")))))
+        (context (Vcs_git_backend.Num_status.parse_line_exn ((line "A\tB\tC\tD"))))
+        (error "Unexpected output from git diff."))))
     ("A\tB\tC" (
       Error (
-        Vcs.E (
-          (context (Vcs_git_backend.Num_status.parse_line_exn ((line "A\tB\tC"))))
-          (error (
-            "Unexpected output from git diff." (
-              (insertions (Other A))
-              (deletions  (Other B)))))))))
+        (context (Vcs_git_backend.Num_status.parse_line_exn ((line "A\tB\tC"))))
+        (error (
+          "Unexpected output from git diff." (
+            (insertions (Other A))
+            (deletions  (Other B))))))))
     ("0\t1\tfile" (
       Ok (
         (key (One_file file))
@@ -537,37 +531,32 @@ let%expect_test "parse_lines_exn" =
     ("-\t-\tfile" (Ok ((key (One_file file)) (num_stat Binary_file))))
     ("-\t10\tfile" (
       Error (
-        Vcs.E (
-          (context (
-            Vcs_git_backend.Num_status.parse_line_exn ((line "-\t10\tfile"))))
-          (error (
-            "Unexpected output from git diff." (
-              (insertions Dash) (deletions (Num 10)))))))))
+        (context (
+          Vcs_git_backend.Num_status.parse_line_exn ((line "-\t10\tfile"))))
+        (error (
+          "Unexpected output from git diff." (
+            (insertions Dash) (deletions (Num 10))))))))
     ("7\t-\tfile" (
       Error (
-        Vcs.E (
-          (context (
-            Vcs_git_backend.Num_status.parse_line_exn ((line "7\t-\tfile"))))
-          (error (
-            "Unexpected output from git diff." (
-              (insertions (Num 7)) (deletions Dash))))))))
+        (context (Vcs_git_backend.Num_status.parse_line_exn ((line "7\t-\tfile"))))
+        (error (
+          "Unexpected output from git diff." (
+            (insertions (Num 7)) (deletions Dash)))))))
     ("-2\t-10\tfile" (
       Error (
-        Vcs.E (
-          (context (
-            Vcs_git_backend.Num_status.parse_line_exn ((line "-2\t-10\tfile"))))
-          (error (
-            "Unexpected output from git diff." (
-              (insertions (Other -2))
-              (deletions  (Other -10)))))))))
+        (context (
+          Vcs_git_backend.Num_status.parse_line_exn ((line "-2\t-10\tfile"))))
+        (error (
+          "Unexpected output from git diff." (
+            (insertions (Other -2))
+            (deletions  (Other -10))))))))
     ("1985\t0\tfile1 => /tmp/file2" (
       Error (
-        Vcs.E (
-          (context
-            (Vcs_git_backend.Num_status.parse_line_exn
-             ((line "1985\t0\tfile1 => /tmp/file2")))
-            (Vcs_git_backend.Munged_path.parse_exn ((path "file1 => /tmp/file2"))))
-          (error (Invalid_argument "\"/tmp/file2\": not a relative path"))))))
+        (context
+          (Vcs_git_backend.Num_status.parse_line_exn
+           ((line "1985\t0\tfile1 => /tmp/file2")))
+          (Vcs_git_backend.Munged_path.parse_exn ((path "file1 => /tmp/file2"))))
+        (error (Invalid_argument "\"/tmp/file2\": not a relative path")))))
     |}];
   ()
 ;;

--- a/lib/vcs_git_backend/test/test__refs.ml
+++ b/lib/vcs_git_backend/test/test__refs.ml
@@ -62,7 +62,7 @@ let%expect_test "parse_ref_kind_exn" =
     {|
     (Vcs.E (
       (context (Vcs_git_backend.Refs.parse_ref_kind_exn ((ref_kind blah))))
-      (error "Expected ref to start with 'refs/'")))
+      (error "Expected ref to start with ['refs/'].")))
     |}];
   require_does_raise [%here] (fun () -> test_ref_kind "non-refs/tags/0.0.1");
   [%expect
@@ -70,7 +70,7 @@ let%expect_test "parse_ref_kind_exn" =
     (Vcs.E (
       (context (
         Vcs_git_backend.Refs.parse_ref_kind_exn ((ref_kind non-refs/tags/0.0.1))))
-      (error "Expected ref to start with 'refs/'")))
+      (error "Expected ref to start with ['refs/'].")))
     |}];
   test_ref_kind "refs/blah";
   [%expect {| (Other (name blah)) |}];
@@ -110,7 +110,7 @@ let%expect_test "dereferenced" =
     {|
     (Vcs.E (
       (context (Vcs_git_backend.Refs.Dereferenced.parse_exn ((line ""))))
-      (error "Invalid ref line")))
+      (error "Invalid ref line.")))
     |}];
   test "1185512b92d612b25613f2e5b473e5231185512b refs/heads/main";
   [%expect

--- a/lib/vcs_git_backend/test/test__refs.ml
+++ b/lib/vcs_git_backend/test/test__refs.ml
@@ -61,15 +61,15 @@ let%expect_test "parse_ref_kind_exn" =
   [%expect
     {|
     (Vcs.E (
-      (steps ((Vcs_git_backend.Refs.parse_ref_kind_exn ((ref_kind blah)))))
+      (context (Vcs_git_backend.Refs.parse_ref_kind_exn ((ref_kind blah))))
       (error "Expected ref to start with 'refs/'")))
     |}];
   require_does_raise [%here] (fun () -> test_ref_kind "non-refs/tags/0.0.1");
   [%expect
     {|
     (Vcs.E (
-      (steps ((
-        Vcs_git_backend.Refs.parse_ref_kind_exn ((ref_kind non-refs/tags/0.0.1)))))
+      (context (
+        Vcs_git_backend.Refs.parse_ref_kind_exn ((ref_kind non-refs/tags/0.0.1))))
       (error "Expected ref to start with 'refs/'")))
     |}];
   test_ref_kind "refs/blah";
@@ -82,8 +82,8 @@ let%expect_test "parse_ref_kind_exn" =
   [%expect
     {|
     (Vcs.E (
-      (steps ((
-        Vcs_git_backend.Refs.parse_ref_kind_exn ((ref_kind refs/remotes/blah)))))
+      (context (
+        Vcs_git_backend.Refs.parse_ref_kind_exn ((ref_kind refs/remotes/blah))))
       (error (Invalid_argument "\"blah\": invalid remote_branch_name"))))
     |}];
   test_ref_kind "refs/remotes/origin/main";
@@ -109,7 +109,7 @@ let%expect_test "dereferenced" =
   [%expect
     {|
     (Vcs.E (
-      (steps ((Vcs_git_backend.Refs.Dereferenced.parse_exn ((line "")))))
+      (context (Vcs_git_backend.Refs.Dereferenced.parse_exn ((line ""))))
       (error "Invalid ref line")))
     |}];
   test "1185512b92d612b25613f2e5b473e5231185512b refs/heads/main";

--- a/lib/vcs_git_backend/test/test__refs.ml
+++ b/lib/vcs_git_backend/test/test__refs.ml
@@ -60,17 +60,15 @@ let%expect_test "parse_ref_kind_exn" =
   require_does_raise [%here] (fun () -> test_ref_kind "blah");
   [%expect
     {|
-    (Vcs.E (
-      (context (Vcs_git_backend.Refs.parse_ref_kind_exn ((ref_kind blah))))
-      (error "Expected ref to start with ['refs/'].")))
+    ((context (Vcs_git_backend.Refs.parse_ref_kind_exn ((ref_kind blah))))
+     (error "Expected ref to start with ['refs/']."))
     |}];
   require_does_raise [%here] (fun () -> test_ref_kind "non-refs/tags/0.0.1");
   [%expect
     {|
-    (Vcs.E (
-      (context (
-        Vcs_git_backend.Refs.parse_ref_kind_exn ((ref_kind non-refs/tags/0.0.1))))
-      (error "Expected ref to start with ['refs/'].")))
+    ((context (
+       Vcs_git_backend.Refs.parse_ref_kind_exn ((ref_kind non-refs/tags/0.0.1))))
+     (error "Expected ref to start with ['refs/']."))
     |}];
   test_ref_kind "refs/blah";
   [%expect {| (Other (name blah)) |}];
@@ -81,10 +79,9 @@ let%expect_test "parse_ref_kind_exn" =
   require_does_raise [%here] (fun () -> test_ref_kind "refs/remotes/blah");
   [%expect
     {|
-    (Vcs.E (
-      (context (
-        Vcs_git_backend.Refs.parse_ref_kind_exn ((ref_kind refs/remotes/blah))))
-      (error (Invalid_argument "\"blah\": invalid remote_branch_name"))))
+    ((context (
+       Vcs_git_backend.Refs.parse_ref_kind_exn ((ref_kind refs/remotes/blah))))
+     (error (Invalid_argument "\"blah\": invalid remote_branch_name")))
     |}];
   test_ref_kind "refs/remotes/origin/main";
   [%expect
@@ -108,9 +105,8 @@ let%expect_test "dereferenced" =
   require_does_raise [%here] (fun () -> test "");
   [%expect
     {|
-    (Vcs.E (
-      (context (Vcs_git_backend.Refs.Dereferenced.parse_exn ((line ""))))
-      (error "Invalid ref line.")))
+    ((context (Vcs_git_backend.Refs.Dereferenced.parse_exn ((line ""))))
+     (error "Invalid ref line."))
     |}];
   test "1185512b92d612b25613f2e5b473e5231185512b refs/heads/main";
   [%expect

--- a/lib/vcs_git_backend/test/test__show.ml
+++ b/lib/vcs_git_backend/test/test__show.ml
@@ -31,6 +31,6 @@ let%expect_test "show" =
   test { exit_code = 128; stdout = "contents"; stderr = "" };
   [%expect {| (Ok Absent) |}];
   test { exit_code = 1; stdout = "contents"; stderr = "" };
-  [%expect {| (Error ("unexpected exit code" ((accepted_codes (0 128))))) |}];
+  [%expect {| (Error ("Unexpected exit code." ((accepted_codes (0 128))))) |}];
   ()
 ;;

--- a/lib/vcs_git_eio/src/runtime.ml
+++ b/lib/vcs_git_eio/src/runtime.ml
@@ -156,7 +156,7 @@ let git ?env t ~cwd ~args ~f =
       raise_notrace
         (Vcs.E
            (Vcs.Err.create_s
-              [%sexp "process exited abnormally", { signal : int }] [@coverage off]))
+              [%sexp "Process exited abnormally.", { signal : int }] [@coverage off]))
       [@coverage off]
     | `Exited exit_code ->
       (* A note regarding the [raise_notrace] below. These cases are indeed

--- a/lib/vcs_git_eio/test/test__file_system.ml
+++ b/lib/vcs_git_eio/test/test__file_system.ml
@@ -55,7 +55,7 @@ let%expect_test "read_dir" =
       print_s
         (Vcs_test_helpers.redact_sexp (Vcs.Err.sexp_of_t err) ~fields:[ "dir"; "error" ])
   in
-  [%expect {| ((steps ((Vcs.read_dir ((dir <REDACTED>))))) (error <REDACTED>)) |}];
+  [%expect {| ((context (Vcs.read_dir ((dir <REDACTED>)))) (error <REDACTED>)) |}];
   let () =
     (* [Vcs.read_dir] errors out when called on an existing file rather than a
        directory. *)
@@ -70,6 +70,6 @@ let%expect_test "read_dir" =
       print_s
         (Vcs_test_helpers.redact_sexp (Vcs.Err.sexp_of_t err) ~fields:[ "dir"; "error" ])
   in
-  [%expect {| ((steps ((Vcs.read_dir ((dir <REDACTED>))))) (error <REDACTED>)) |}];
+  [%expect {| ((context (Vcs.read_dir ((dir <REDACTED>)))) (error <REDACTED>)) |}];
   ()
 ;;

--- a/lib/vcs_git_unix/test/test__file_system.ml
+++ b/lib/vcs_git_unix/test/test__file_system.ml
@@ -51,7 +51,7 @@ let%expect_test "read_dir" =
   in
   [%expect
     {|
-    ((steps ((Vcs.read_dir ((dir <REDACTED>)))))
+    ((context (Vcs.read_dir ((dir <REDACTED>))))
      (error (Sys_error "/non-existing: No such file or directory")))
     |}];
   let () =
@@ -68,6 +68,6 @@ let%expect_test "read_dir" =
       print_s
         (Vcs_test_helpers.redact_sexp (Vcs.Err.sexp_of_t err) ~fields:[ "dir"; "error" ])
   in
-  [%expect {| ((steps ((Vcs.read_dir ((dir <REDACTED>))))) (error <REDACTED>)) |}];
+  [%expect {| ((context (Vcs.read_dir ((dir <REDACTED>)))) (error <REDACTED>)) |}];
   ()
 ;;

--- a/lib/vcs_git_unix/test/test__hello_commit.ml
+++ b/lib/vcs_git_unix/test/test__hello_commit.ml
@@ -89,7 +89,7 @@ let%expect_test "read_dir" =
   in
   [%expect
     {|
-    ((steps ((Vcs.read_dir ((dir /invalid)))))
+    ((context (Vcs.read_dir ((dir /invalid))))
      (error (Sys_error "/invalid: No such file or directory")))
     |}];
   ()

--- a/lib/vcs_git_unix/test/test__path_resolution.ml
+++ b/lib/vcs_git_unix/test/test__path_resolution.ml
@@ -77,14 +77,14 @@ let%expect_test "hello path" =
   test_with_env ~vcs ~env:None ~redact_fields:[ "cwd"; "prog"; "repo_root"; "stderr" ];
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.git ((repo_root <REDACTED>) (args (rev-parse INVALID-REF))))
        ((prog <REDACTED>)
         (args        (rev-parse INVALID-REF))
         (exit_status (Exited    128))
         (cwd    <REDACTED>)
         (stdout INVALID-REF)
-        (stderr <REDACTED>))))
+        (stderr <REDACTED>)))
      (error "expected exit code 0"))
     |}];
   let bin = Absolute_path.extend cwd (Fsegment.v "bin") in
@@ -122,7 +122,7 @@ let%expect_test "hello path" =
     ~redact_fields:[ "cwd"; "env"; "prog"; "repo_root"; "stderr" ];
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.git (
          (repo_root <REDACTED>)
          (env       <REDACTED>)
@@ -132,7 +132,7 @@ let%expect_test "hello path" =
         (exit_status (Exited    128))
         (cwd    <REDACTED>)
         (stdout INVALID-REF)
-        (stderr <REDACTED>))))
+        (stderr <REDACTED>)))
      (error "expected exit code 0"))
     |}];
   (* If we extend the environment in a way that changes PATH, we rerun the
@@ -147,7 +147,7 @@ let%expect_test "hello path" =
   test_with_env ~vcs ~env:(Some extended_env) ~redact_fields:[ "cwd"; "env"; "repo_root" ];
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.git (
          (repo_root <REDACTED>)
          (env       <REDACTED>)
@@ -157,7 +157,7 @@ let%expect_test "hello path" =
         (exit_status (Exited    42))
         (cwd    <REDACTED>)
         (stdout "Hello Git!")
-        (stderr ""))))
+        (stderr "")))
      (error "expected exit code 0"))
     |}];
   (* Under an empty environment, we expect to revert to the previous git binary. *)
@@ -167,7 +167,7 @@ let%expect_test "hello path" =
     ~redact_fields:[ "cwd"; "env"; "prog"; "repo_root"; "stderr" ];
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.git (
          (repo_root <REDACTED>)
          (env       <REDACTED>)
@@ -177,7 +177,7 @@ let%expect_test "hello path" =
         (exit_status (Exited    128))
         (cwd    <REDACTED>)
         (stdout INVALID-REF)
-        (stderr <REDACTED>))))
+        (stderr <REDACTED>)))
      (error "expected exit code 0"))
     |}];
   (* The initial PATH under which the [vcs] is created is used to pre locate the executable. *)
@@ -187,14 +187,14 @@ let%expect_test "hello path" =
   test_with_env ~vcs ~env:None ~redact_fields:[ "cwd"; "env"; "prog"; "repo_root" ];
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.git ((repo_root <REDACTED>) (args (rev-parse INVALID-REF))))
        ((prog <REDACTED>)
         (args        (rev-parse INVALID-REF))
         (exit_status (Exited    42))
         (cwd    <REDACTED>)
         (stdout "Hello Git!")
-        (stderr ""))))
+        (stderr "")))
      (error "expected exit code 0"))
     |}];
   (* Let's monitor the behavior when no Git executable is found in the PATH. In
@@ -205,14 +205,14 @@ let%expect_test "hello path" =
   test_with_env ~vcs ~env:None ~redact_fields:[ "cwd"; "env"; "repo_root" ];
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.git ((repo_root <REDACTED>) (args (rev-parse INVALID-REF))))
        ((prog git)
         (args (rev-parse INVALID-REF))
         (exit_status Unknown)
         (cwd         <REDACTED>)
         (stdout      "")
-        (stderr      ""))))
+        (stderr      "")))
      (error (Failure "git: command not found")))
     |}];
   Option.iter save_path ~f:(fun path -> Unix.putenv "PATH" path);

--- a/lib/vcs_git_unix/test/test__path_resolution.ml
+++ b/lib/vcs_git_unix/test/test__path_resolution.ml
@@ -85,7 +85,7 @@ let%expect_test "hello path" =
         (cwd    <REDACTED>)
         (stdout INVALID-REF)
         (stderr <REDACTED>)))
-     (error "expected exit code 0"))
+     (error "Expected exit code 0."))
     |}];
   let bin = Absolute_path.extend cwd (Fsegment.v "bin") in
   Unix.mkdir (bin |> Absolute_path.to_string) ~perm:0o755;
@@ -133,7 +133,7 @@ let%expect_test "hello path" =
         (cwd    <REDACTED>)
         (stdout INVALID-REF)
         (stderr <REDACTED>)))
-     (error "expected exit code 0"))
+     (error "Expected exit code 0."))
     |}];
   (* If we extend the environment in a way that changes PATH, we rerun the
      executable resolution. *)
@@ -158,7 +158,7 @@ let%expect_test "hello path" =
         (cwd    <REDACTED>)
         (stdout "Hello Git!")
         (stderr "")))
-     (error "expected exit code 0"))
+     (error "Expected exit code 0."))
     |}];
   (* Under an empty environment, we expect to revert to the previous git binary. *)
   test_with_env
@@ -178,7 +178,7 @@ let%expect_test "hello path" =
         (cwd    <REDACTED>)
         (stdout INVALID-REF)
         (stderr <REDACTED>)))
-     (error "expected exit code 0"))
+     (error "Expected exit code 0."))
     |}];
   (* The initial PATH under which the [vcs] is created is used to pre locate the executable. *)
   let save_path = Stdlib.Sys.getenv_opt "PATH" in
@@ -195,7 +195,7 @@ let%expect_test "hello path" =
         (cwd    <REDACTED>)
         (stdout "Hello Git!")
         (stderr "")))
-     (error "expected exit code 0"))
+     (error "Expected exit code 0."))
     |}];
   (* Let's monitor the behavior when no Git executable is found in the PATH. In
      this case, the [prog] is left as "git" and we rely on the backend process

--- a/lib/vcs_test_helpers/test/test__vcs_test_helpers.ml
+++ b/lib/vcs_test_helpers/test/test__vcs_test_helpers.ml
@@ -75,40 +75,41 @@ let%expect_test "redact_sexp" =
   print_s (Vcs_test_helpers.redact_sexp error ~fields:[ "error" ]);
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.init ((path /invalid/path)))
        ((prog git)
         (args (init .))
         (exit_status Unknown)
         (cwd         /invalid/path)
         (stdout      "")
-        (stderr      ""))))
+        (stderr      "")))
      (error <REDACTED>))
     |}];
-  print_s (Vcs_test_helpers.redact_sexp error ~fields:[ "error"; "steps/cwd" ]);
+  print_s (Vcs_test_helpers.redact_sexp error ~fields:[ "error"; "context/cwd" ]);
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.init ((path /invalid/path)))
        ((prog git)
         (args (init .))
         (exit_status Unknown)
         (cwd         <REDACTED>)
         (stdout      "")
-        (stderr      ""))))
+        (stderr      "")))
      (error <REDACTED>))
     |}];
-  print_s (Vcs_test_helpers.redact_sexp error ~fields:[ "error"; "steps/stderr"; "cwd" ]);
+  print_s
+    (Vcs_test_helpers.redact_sexp error ~fields:[ "error"; "context/stderr"; "cwd" ]);
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.init ((path /invalid/path)))
        ((prog git)
         (args (init .))
         (exit_status Unknown)
         (cwd         <REDACTED>)
         (stdout      "")
-        (stderr      <REDACTED>))))
+        (stderr      <REDACTED>)))
      (error <REDACTED>))
     |}];
   (* Adding corner cases, such as empty nested fields. *)

--- a/test/cram/run.t
+++ b/test/cram/run.t
@@ -57,10 +57,10 @@ File system operations.
 
   $ ocaml-vcs read-dir untracked
   Error:
-  ((steps
-    ((Vcs.read_dir
-      ((dir
-        $TESTCASE_ROOT/untracked)))))
+  ((context
+    (Vcs.read_dir
+     ((dir
+       $TESTCASE_ROOT/untracked))))
    (error
     (Sys_error
      "$TESTCASE_ROOT/untracked: No such file or directory")))
@@ -78,10 +78,10 @@ File system operations.
 
   $ ocaml-vcs read-dir untracked/hello
   Error:
-  ((steps
-    ((Vcs.read_dir
-      ((dir
-        $TESTCASE_ROOT/untracked/hello)))))
+  ((context
+    (Vcs.read_dir
+     ((dir
+       $TESTCASE_ROOT/untracked/hello))))
    (error
     (Sys_error
      "$TESTCASE_ROOT/untracked/hello: Not a directory")))
@@ -93,10 +93,10 @@ File system operations.
   $ chmod -r untracked
   $ ocaml-vcs read-dir untracked
   Error:
-  ((steps
-    ((Vcs.read_dir
-      ((dir
-        $TESTCASE_ROOT/untracked)))))
+  ((context
+    (Vcs.read_dir
+     ((dir
+       $TESTCASE_ROOT/untracked))))
    (error
     (Sys_error
      "$TESTCASE_ROOT/untracked: Permission denied")))

--- a/test/cram/run.t
+++ b/test/cram/run.t
@@ -36,7 +36,7 @@ Rev-parse.
   rev0
 
   $ ocaml-vcs branch-revision unknown-branch
-  Error: Branch not found (branch_name unknown-branch)
+  Error: Branch not found. (branch_name unknown-branch)
   [123]
 
 Testing a successful file show with git and via vcs.
@@ -50,7 +50,7 @@ Testing a successful file show with git and via vcs.
 Invalid path-in-repo.
 
   $ ocaml-vcs show-file-at-rev /hello -r $rev0
-  Error: Path is not in repo (path /hello)
+  Error: Path is not in repo. (path /hello)
   [123]
 
 File system operations.
@@ -108,7 +108,7 @@ File system operations.
 Find enclosing repo root.
 
   $ (cd "/" && ocaml-vcs current-revision)
-  Error: Failed to locate enclosing repo root from directory (from /)
+  Error: Failed to locate enclosing repo root from directory. (from /)
   [123]
 
   $ ocaml-vcs find-enclosing-repo-root
@@ -143,7 +143,7 @@ Adding a new file under a directory.
   $ ocaml-vcs ls-files --below dir
   dir/hello
   $ ocaml-vcs ls-files --below /dir
-  Error: Path is not in repo (path /dir)
+  Error: Path is not in repo. (path /dir)
   [123]
 
 Testing an unsuccessful file show with git and via vcs.
@@ -210,7 +210,7 @@ Greatest common ancestors.
   ($REV1)
 
   $ ocaml-vcs gca $rev1 2e9ab12edfe8e3a01cf2fa2b46210c042e9ab12e
-  Error: Rev not found (rev 2e9ab12edfe8e3a01cf2fa2b46210c042e9ab12e)
+  Error: Rev not found. (rev 2e9ab12edfe8e3a01cf2fa2b46210c042e9ab12e)
   [123]
 
 Descendance.
@@ -225,7 +225,7 @@ Descendance.
   Strict_descendant
 
   $ ocaml-vcs descendance $rev1 2e9ab12edfe8e3a01cf2fa2b46210c042e9ab12e
-  Error: Rev not found (rev 2e9ab12edfe8e3a01cf2fa2b46210c042e9ab12e)
+  Error: Rev not found. (rev 2e9ab12edfe8e3a01cf2fa2b46210c042e9ab12e)
   [123]
 
 Vcs allows to run the git command line directly if the backend supports it.

--- a/test/expect/git_exception_handler.ml
+++ b/test/expect/git_exception_handler.ml
@@ -74,7 +74,7 @@ end
 let handler (handler_scenario : Handler_scenario.t) =
   match handler_scenario with
   | Ok -> Ok [%sexp ()]
-  | Error -> Error (Vcs.Err.error_string "expected exit code 0")
+  | Error -> Error (Vcs.Err.error_string "Expected exit code 0.")
   | Raise_failure -> failwith "Raise_failure"
   | Raise_invalid_argument -> invalid_arg "Raise_invalid_argument"
   | Raise_custom_exception -> raise Handler_scenario.Custom_exception
@@ -155,7 +155,7 @@ let%expect_test "eio" =
               (cwd    <REDACTED>)
               (stdout error)
               (stderr "")))
-            (error "expected exit code 0"))
+            (error "Expected exit code 0."))
            |}])
     | Raise_failure ->
       require_does_raise [%here] test;
@@ -216,7 +216,7 @@ let%expect_test "blocking" =
               (cwd    <REDACTED>)
               (stdout error)
               (stderr "")))
-            (error "expected exit code 0"))
+            (error "Expected exit code 0."))
            |}])
     | Raise_failure ->
       require_does_raise [%here] test;

--- a/test/expect/git_exception_handler.ml
+++ b/test/expect/git_exception_handler.ml
@@ -148,13 +148,13 @@ let%expect_test "eio" =
          print_s (Vcs_test_helpers.redact_sexp (Vcs.Err.sexp_of_t err) ~fields:[ "cwd" ]);
          [%expect
            {|
-           ((steps ((
+           ((context (
               (prog git)
               (args (rev-parse --abbrev-ref HEAD))
               (exit_status (Exited 0))
               (cwd    <REDACTED>)
               (stdout error)
-              (stderr ""))))
+              (stderr "")))
             (error "expected exit code 0"))
            |}])
     | Raise_failure ->
@@ -209,13 +209,13 @@ let%expect_test "blocking" =
               ~fields:[ "cwd"; "prog" ]);
          [%expect
            {|
-           ((steps ((
+           ((context (
               (prog <REDACTED>)
               (args (rev-parse --abbrev-ref HEAD))
               (exit_status (Exited 0))
               (cwd    <REDACTED>)
               (stdout error)
-              (stderr ""))))
+              (stderr "")))
             (error "expected exit code 0"))
            |}])
     | Raise_failure ->

--- a/test/expect/git_exception_handler.ml
+++ b/test/expect/git_exception_handler.ml
@@ -169,7 +169,7 @@ let%expect_test "eio" =
         {| (Vcs_expect_tests.Git_exception_handler.Handler_scenario.Custom_exception) |}]
     | Raise_vcs_exception ->
       require_does_raise [%here] test;
-      [%expect {| (Vcs.E Raise_vcs_exception) |}]);
+      [%expect {| Raise_vcs_exception |}]);
   ()
 ;;
 
@@ -230,6 +230,6 @@ let%expect_test "blocking" =
         {| (Vcs_expect_tests.Git_exception_handler.Handler_scenario.Custom_exception) |}]
     | Raise_vcs_exception ->
       require_does_raise [%here] test;
-      [%expect {| (Vcs.E Raise_vcs_exception) |}]);
+      [%expect {| Raise_vcs_exception |}]);
   ()
 ;;

--- a/test/expect/small_graph.ml
+++ b/test/expect/small_graph.ml
@@ -77,7 +77,7 @@ let%expect_test "small graph" =
         (cwd    <REDACTED>)
         (stdout "")
         (stderr "fatal: pathspec 'unknown-file.txt' did not match any files")))
-     (error "expected exit code 0"))
+     (error "Expected exit code 0."))
     |}];
   let () =
     match
@@ -103,7 +103,7 @@ let%expect_test "small graph" =
         (cwd    <REDACTED>)
         (stdout <REDACTED>)
         (stderr "")))
-     (error "expected exit code 0"))
+     (error "Expected exit code 0."))
     |}];
   let commit_file ~path ~file_contents =
     let result =

--- a/test/expect/small_graph.ml
+++ b/test/expect/small_graph.ml
@@ -67,7 +67,7 @@ let%expect_test "small graph" =
   in
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.add (
          (repo_root <REDACTED>)
          (path      unknown-file.txt)))
@@ -76,7 +76,7 @@ let%expect_test "small graph" =
         (exit_status (Exited 128))
         (cwd    <REDACTED>)
         (stdout "")
-        (stderr "fatal: pathspec 'unknown-file.txt' did not match any files"))))
+        (stderr "fatal: pathspec 'unknown-file.txt' did not match any files")))
      (error "expected exit code 0"))
     |}];
   let () =
@@ -95,14 +95,14 @@ let%expect_test "small graph" =
   in
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.commit ((repo_root <REDACTED>)))
        ((prog git)
         (args (commit -m "Nothing to commit"))
         (exit_status (Exited 1))
         (cwd    <REDACTED>)
         (stdout <REDACTED>)
-        (stderr ""))))
+        (stderr "")))
      (error "expected exit code 0"))
     |}];
   let commit_file ~path ~file_contents =
@@ -180,7 +180,7 @@ let%expect_test "small graph" =
   in
   [%expect
     {|
-    ((steps (
+    ((context
        (Vcs.ls_files (
          (repo_root <REDACTED>)
          (below     dir)))
@@ -189,7 +189,7 @@ let%expect_test "small graph" =
         (exit_status Unknown)
         (cwd         <REDACTED>)
         (stdout      "")
-        (stderr      ""))))
+        (stderr      "")))
      (error <REDACTED>))
     |}];
   let foo_file = Vcs.Path_in_repo.v "foo.txt" in


### PR DESCRIPTION
I'm working on a larger refactoring that aims to unify the errors used in vcs with some other projects. To simplify for upcoming refactoring(s), I've made this preparatory change to isolate some changes to the sexp format of errors and exceptions in Vcs.
