### PR TITLE
Partial OCaml 4.14 support

### DIFF
--- a/.github/workflows/ocaml-4-ci.yml
+++ b/.github/workflows/ocaml-4-ci.yml
@@ -1,0 +1,56 @@
+# In this workflow we test the build for a subset of the packages of the repo
+# that are compatible with OCaml 4.14.
+
+name: ocaml-4-ci
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "**" # This will match pull requests targeting any branch
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+        ocaml-compiler:
+          - 4.14.x
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          opam-repositories: |
+            default: https://github.com/ocaml/opam-repository.git
+            mbarbin: https://github.com/mbarbin/opam-repository.git
+      #     janestreet-bleeding: https://github.com/janestreet/opam-repository.git
+      #     janestreet-bleeding-external: https://github.com/janestreet/opam-repository.git#external-packages
+
+      # This construct is not well supported by older OCaml versions. Given that
+      # we already check the build with this option in the main CI job, we
+      # disable it here unconditionally for simplicity.
+      - name: Edit dune-project
+        shell: pwsh
+        run: |
+          (Get-Content dune-project) -notmatch '\(implicit_transitive_deps false\)' | Set-Content dune-project
+
+      # We build and run tests for a subset of packages. More tests are run in
+      # the development workflow and as part of the main CI job. These are the
+      # tests that are checked for every combination of os and ocaml-compiler.
+      - name: Install dependencies
+        run: opam install ./vcs.opam ./vcs-git-backend.opam ./vcs-git-unix.opam --deps-only --with-test
+
+      - name: Build & Run tests
+        run: opam exec -- dune build @all @runtest -p vcs,vcs-git-backend,vcs-git-unix

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
-## 0.0.15 (unreleased)
+## 0.0.15 (2025-05-22)
 
 ### Added
+
+- Add support for OCaml-4.14 to `vcs`, `vcs-git-backend` & `vcs-git-unix` (#64, @mbarbin).
 
 ### Changed
 
@@ -8,17 +10,13 @@
 
 ### Deprecated
 
-- Actually mark for deprecation all the functions, modules and exceptions that were prepared to be deprecated (@mbarbin).
-
-### Fixed
-
-### Removed
+- Actually mark for deprecation all the functions, modules and exceptions that were prepared to be deprecated (#64, @mbarbin).
 
 ## 0.0.14 (2025-05-07)
 
 This release prepares the deprecation of a few functions and contains `ocamlmig` annotations to help users with the migration.
 
-To automatically apply the migration changes, first upgrade your `pplumbing` dependency and re-build your project. Then run the command `ocamlmig migrate` from the root of your project.
+To automatically apply the migration changes, first upgrade your `vcs` dependency and re-build your project. Then run the command `ocamlmig migrate` from the root of your project.
 
 ### Added
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,11 +8,17 @@
 
 ### Deprecated
 
+- Actually mark for deprecation all the functions, modules and exceptions that were prepared to be deprecated (@mbarbin).
+
 ### Fixed
 
 ### Removed
 
 ## 0.0.14 (2025-05-07)
+
+This release prepares the deprecation of a few functions and contains `ocamlmig` annotations to help users with the migration.
+
+To automatically apply the migration changes, first upgrade your `pplumbing` dependency and re-build your project. Then run the command `ocamlmig migrate` from the root of your project.
 
 ### Added
 

--- a/dune
+++ b/dune
@@ -1,4 +1,0 @@
-(env
- (dev
-  (odoc
-   (warnings fatal))))

--- a/dune-project
+++ b/dune-project
@@ -24,7 +24,7 @@
  (synopsis "A Versatile OCaml Library for Git Operations")
  (depends
   (ocaml
-   (>= 5.2))
+   (>= 4.14))
   (astring
    (>= 0.8.5))
   (fpath
@@ -36,17 +36,11 @@
   (pplumbing
    (>= 0.0.13))
   (ppx_enumerate
-   (and
-    (>= v0.17)
-    (< v0.18)))
+   (>= v0.16))
   (ppx_sexp_conv
-   (and
-    (>= v0.17)
-    (< v0.18)))
+   (>= v0.16))
   (ppx_sexp_value
-   (and
-    (>= v0.17)
-    (< v0.18)))
+   (>= v0.16))
   (ppxlib
    (>= 0.33))))
 
@@ -137,7 +131,7 @@
  (synopsis "An IO-free library that parses the output of Git commands")
  (depends
   (ocaml
-   (>= 5.2))
+   (>= 4.14))
   (astring
    (>= 0.8.5))
   (fpath
@@ -149,19 +143,13 @@
   (pplumbing
    (>= 0.0.13))
   (ppx_sexp_conv
-   (and
-    (>= v0.17)
-    (< v0.18)))
+   (>= v0.16))
   (ppx_sexp_value
-   (and
-    (>= v0.17)
-    (< v0.18)))
+   (>= v0.16))
   (ppxlib
    (>= 0.33))
   (sexplib0
-   (and
-    (>= v0.17)
-    (< v0.18)))
+   (>= v0.16))
   (vcs
    (= :version))))
 
@@ -206,7 +194,7 @@
   "A Git backend for Vcs based on Vcs_git_backend and the Unix library")
  (depends
   (ocaml
-   (>= 5.2))
+   (>= 4.14))
   (fpath
    (>= 0.7.3))
   (fpath-sexp0
@@ -216,23 +204,15 @@
   (pplumbing
    (>= 0.0.13))
   (ppx_sexp_conv
-   (and
-    (>= v0.17)
-    (< v0.18)))
+   (>= v0.16))
   (ppx_sexp_value
-   (and
-    (>= v0.17)
-    (< v0.18)))
+   (>= v0.16))
   (ppxlib
    (>= 0.33))
   (sexplib0
-   (and
-    (>= v0.17)
-    (< v0.18)))
+   (>= v0.16))
   (shexp
-   (and
-    (>= v0.17)
-    (< v0.18)))
+   (>= v0.16))
   (vcs
    (= :version))
   (vcs-git-backend

--- a/lib/vcs/src/dune
+++ b/lib/vcs/src/dune
@@ -13,7 +13,9 @@
   Sexplib0
   -open
   Sexplib0.Sexp_conv)
- (libraries astring fpath fpath-sexp0 pp pplumbing.err)
+ (libraries astring fpath fpath-sexp0 pp pplumbing.err pplumbing.pp-tty)
+ (modules
+  (:standard \ stdlib_compat4xx stdlib_compat5xx))
  (instrumentation
   (backend bisect_ppx))
  (lint
@@ -25,3 +27,31 @@
    ppx_enumerate
    ppx_sexp_conv
    ppx_sexp_value)))
+
+(rule
+ (enabled_if
+  (< %{ocaml_version} 5.0))
+ (target stdlib_compat.ml)
+ (action
+  (copy stdlib_compat4xx.ml %{target})))
+
+(rule
+ (enabled_if
+  (>= %{ocaml_version} 5.0))
+ (target stdlib_compat.ml)
+ (action
+  (copy stdlib_compat5xx.ml %{target})))
+
+(rule
+ (enabled_if
+  (< %{ocaml_version} 5.0))
+ (target stdlib_compat.mli)
+ (action
+  (copy stdlib_compat4xx.mli %{target})))
+
+(rule
+ (enabled_if
+  (>= %{ocaml_version} 5.0))
+ (target stdlib_compat.mli)
+ (action
+  (copy stdlib_compat5xx.mli %{target})))

--- a/lib/vcs/src/import.ml
+++ b/lib/vcs/src/import.ml
@@ -19,6 +19,8 @@
 (*  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*******************************************************************************)
 
+open! Stdlib_compat
+
 module Array = struct
   include ArrayLabels
 

--- a/lib/vcs/src/import.mli
+++ b/lib/vcs/src/import.mli
@@ -19,6 +19,8 @@
 (*_  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*_******************************************************************************)
 
+open! Stdlib_compat
+
 module Array : sig
   include module type of ArrayLabels
 

--- a/lib/vcs/src/int_table.ml
+++ b/lib/vcs/src/int_table.ml
@@ -19,8 +19,10 @@
 (*  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*******************************************************************************)
 
-include Import.Hashtbl.Make (struct
+open! Import
+
+include Hashtbl.Make (struct
     include Int
 
-    let sexp_of_t t = Sexp.Atom (Import.Int.to_string_hum t)
+    let sexp_of_t t = Sexp.Atom (Int.to_string_hum t)
   end)

--- a/lib/vcs/src/stdlib_compat4xx.ml
+++ b/lib/vcs/src/stdlib_compat4xx.ml
@@ -1,0 +1,29 @@
+module Int = struct
+  include Int
+
+  let hash : int -> int = Hashtbl.hash
+  let seeded_hash : int -> int -> int = Hashtbl.seeded_hash
+end
+
+module ListLabels = struct
+  include ListLabels
+
+  let is_empty = function
+    | [] -> true
+    | _ :: _ -> false
+  ;;
+end
+
+module String = struct
+  include String
+
+  let hash : string -> int = Hashtbl.hash
+  let seeded_hash : int -> string -> int = Hashtbl.seeded_hash
+end
+
+module StringLabels = struct
+  include StringLabels
+
+  let hash : string -> int = Hashtbl.hash
+  let seeded_hash : int -> string -> int = Hashtbl.seeded_hash
+end

--- a/lib/vcs/src/stdlib_compat4xx.mli
+++ b/lib/vcs/src/stdlib_compat4xx.mli
@@ -1,0 +1,26 @@
+module Int : sig
+  include module type of Int
+
+  val hash : t -> int
+  val seeded_hash : int -> int -> int
+end
+
+module ListLabels : sig
+  include module type of ListLabels
+
+  val is_empty : _ t -> bool
+end
+
+module String : sig
+  include module type of String
+
+  val hash : t -> int
+  val seeded_hash : int -> string -> int
+end
+
+module StringLabels : sig
+  include module type of StringLabels
+
+  val hash : t -> int
+  val seeded_hash : int -> string -> int
+end

--- a/lib/vcs/src/vcs.ml
+++ b/lib/vcs/src/vcs.ml
@@ -22,8 +22,6 @@
 module Author = Author
 module Branch_name = Branch_name
 module Commit_message = Commit_message
-module Err = Vcs_err
-module Exn = Vcs_exn
 module File_contents = File_contents
 module Git = Git
 module Graph = Graph
@@ -51,7 +49,6 @@ module Url = Url
 module User_email = User_email
 module User_handle = User_handle
 module User_name = User_name
-include Exn0
 include Vcs0
 
 module Private = struct
@@ -61,4 +58,14 @@ module Private = struct
   module Ref_kind_table = Ref_kind_table
   module Rev_table = Rev_table
   module Validated_string = Validated_string
+
+  let try_with f =
+    match f () with
+    | ok -> Ok ok
+    | exception exn -> Error (Err.of_exn exn)
+  ;;
 end
+
+module Err = Vcs_err
+module Exn = Vcs_exn
+include Exn0

--- a/lib/vcs/src/vcs.mli
+++ b/lib/vcs/src/vcs.mli
@@ -55,6 +55,11 @@ val create : 'a -> 'a t
     printable information. [err] is not meant for pattern matching - we're only
     targeting a non-specialized error recovery.
 
+    [Err.E] is meant to be the only exception ever raised by functions from the
+    [Vcs] interface. [Err.t] doesn't carry the raw backtrace, so you'll need to
+    manipulate the backtrace yourself if you care about it (like you would with
+    any other exceptions).
+
     A general design principle that we follow here is that if an error result is
     of interest for pattern matching, we want to incorporate it into the
     successful branch of the function's result, rather than in its error part -
@@ -66,21 +71,6 @@ val create : 'a -> 'a t
     As library authors we realize that manipulating [Result.t] is a popular
     choice too: we also export the [Vcs]'s functionality via
     {{!non_raising_apis} non-raising APIs} if you prefer. *)
-
-(** Payload of the exception raised by [Vcs] functions. *)
-module Err = Vcs_err
-
-(** [E] is meant to be the only exception ever raised by functions from the
-    [Vcs] interface. [Err.t] doesn't carry the raw backtrace, so you'll need
-    to manipulate the backtrace yourself if you care about it (like you would
-    with any other exceptions).
-
-    The [Vcs.E] exception is equal to [Err.E], which we are in the process of
-    migrating to. [Vcs.E] will be deprecated in a future release, please use
-    [Err.E] instead. *)
-exception E of Err.t
-
-module Exn = Vcs_exn
 
 (** {1 Creating repositories} *)
 
@@ -330,10 +320,9 @@ module Non_raising = Non_raising
 
 module Private : sig
   (** This part of the interface is not stable. Things may break without notice
-      when upgrading to a new version of [Vcs]. This is used e.g. by tests
-      or libraries with strong ties to [Vcs].
-
-      Use at your own risk/convenience! *)
+      and outside of the guidlines set by semver when upgrading to a new version
+      of [Vcs]. This is used e.g. by tests or libraries with strong ties to
+      [Vcs]. Do not use. *)
 
   module Bit_vector = Bit_vector
   module Import = Import
@@ -341,4 +330,29 @@ module Private : sig
   module Ref_kind_table = Ref_kind_table
   module Rev_table = Rev_table
   module Validated_string = Validated_string
+
+  (** [try_with f] runs [f] and wraps any exception it raises into an
+      {!type:Err.t} error. Because this catches all exceptions, including
+      exceptions that may not be designed to be caught (such as
+      [Stack_overflow], [Out_of_memory], etc.) we recommend that code be
+      refactored overtime not to rely on this function. However, this is
+      rather hard to do without assistance from the type checker, thus we
+      currently rely on this function. TBD! *)
+  val try_with : (unit -> 'a) -> ('a, Err.t) Stdlib.Result.t
 end
+
+(** {1 Deprecated API}. *)
+
+module Err = Vcs_err
+[@@ocaml.deprecated "[since 2025-05] Use [pplumbing.Err]. Hint: Run [ocamlmig migrate]"]
+
+(** The [Vcs.E] exception is deprecated and is equal to [Err.E] which should be
+    used instead. *)
+exception
+  E of Err.t
+      [@ocaml.deprecated "[since 2025-05] Use [Err.E]. Hint: Run [ocamlmig migrate]"]
+      [@migrate { repl = Err.E }]
+      [@ocaml.alert "-deprecated"]
+
+module Exn = Vcs_exn
+[@@ocaml.deprecated "[since 2025-05] Use [pplumbing.Err]. Hint: Run [ocamlmig migrate]"]

--- a/lib/vcs/src/vcs.mli
+++ b/lib/vcs/src/vcs.mli
@@ -341,7 +341,7 @@ module Private : sig
   val try_with : (unit -> 'a) -> ('a, Err.t) Stdlib.Result.t
 end
 
-(** {1 Deprecated API}. *)
+(** {1 Deprecated API} *)
 
 module Err = Vcs_err
 [@@ocaml.deprecated "[since 2025-05] Use [pplumbing.Err]. Hint: Run [ocamlmig migrate]"]

--- a/lib/vcs/src/vcs0.ml
+++ b/lib/vcs/src/vcs0.ml
@@ -212,7 +212,9 @@ let non_raising_git
 
 let git ?env ?run_in_subdir vcs ~repo_root ~args ~f =
   non_raising_git ?env ?run_in_subdir vcs ~repo_root ~args ~f:(fun output ->
-    Vcs_exn.Private.try_with (fun () -> f output))
+    match f output with
+    | ok -> Ok ok
+    | exception exn -> Error (Err.of_exn exn))
   |> of_result ~step:(lazy (make_git_err_step ?env ?run_in_subdir ~repo_root ~args ()))
 ;;
 

--- a/lib/vcs/src/vcs_err.ml
+++ b/lib/vcs/src/vcs_err.ml
@@ -32,13 +32,3 @@ let add_context t ~step = Err.add_context t [ Err.sexp step ] [@coverage off]
 let init error ~step =
   Err.add_context (Err.create [ Err.sexp error ]) [ Err.sexp step ] [@coverage off]
 ;;
-
-module Private = struct
-  module Non_raising_M = struct
-    type nonrec t = t
-
-    let sexp_of_t = sexp_of_t
-    let to_err t = t
-    let of_err t = t
-  end
-end

--- a/lib/vcs/src/vcs_err.mli
+++ b/lib/vcs/src/vcs_err.mli
@@ -26,18 +26,26 @@
     existing clients, and we plan on adding deprecation annotations in a future
     release. *)
 
+[@@@ocaml.alert "-deprecated"]
+
 type t = Err.t
+[@@ocaml.deprecated "[since 2025-05] Use [Err.t]. Hint: Run [ocamlmig migrate]"]
+[@@migrate { repl = Err.t; libraries = [ "pplumbing.err" ] }]
 
 (** This is deprecated - use [Err.sexp_of_t] instead. *)
 val sexp_of_t : t -> Sexp.t
+[@@ocaml.deprecated "[since 2025-05] Use [Err.sexp_of_t]. Hint: Run [ocamlmig migrate]"]
 [@@migrate { repl = Err.sexp_of_t; libraries = [ "pplumbing.err" ] }]
 
 (** This is deprecated - use [Err.to_string_hum] instead. *)
 val to_string_hum : t -> string
+[@@ocaml.deprecated
+  "[since 2025-05] Use [Err.to_string_hum]. Hint: Run [ocamlmig migrate]"]
 [@@migrate { repl = Err.to_string_hum; libraries = [ "pplumbing.err" ] }]
 
 (** This is deprecated - use [Err.create] instead. *)
 val error_string : string -> t
+[@@ocaml.deprecated "[since 2025-05] Use [Err.create]. Hint: Run [ocamlmig migrate]"]
 [@@migrate
   { repl = (fun str -> Err.create [ Pp.text str ])
   ; libraries = [ "pp"; "pplumbing.err" ]
@@ -45,15 +53,18 @@ val error_string : string -> t
 
 (** This is deprecated - use [Err.create] instead. *)
 val create_s : Sexp.t -> t
+[@@ocaml.deprecated "[since 2025-05] Use [Err.create]. Hint: Run [ocamlmig migrate]"]
 [@@migrate
   { repl = (fun sexp -> Err.create [ Err.sexp sexp ]); libraries = [ "pplumbing.err" ] }]
 
 (** This is deprecated - use [Err.of_exn] instead. *)
 val of_exn : exn -> t
+[@@ocaml.deprecated "[since 2025-05] Use [Err.of_exn]. Hint: Run [ocamlmig migrate]"]
 [@@migrate { repl = Err.of_exn; libraries = [ "pplumbing.err" ] }]
 
 (** This is deprecated - use [Err.add_context] instead. *)
 val add_context : t -> step:Sexp.t -> t
+[@@ocaml.deprecated "[since 2025-05] Use [Err.add_context]. Hint: Run [ocamlmig migrate]"]
 [@@migrate
   { repl = (fun t ~step -> Err.add_context t [ (Err.sexp step [@commutes]) ])
   ; libraries = [ "pplumbing.err" ]
@@ -61,6 +72,7 @@ val add_context : t -> step:Sexp.t -> t
 
 (** This is deprecated - use [Err.add_context] instead. *)
 val init : Sexp.t -> step:Sexp.t -> t
+[@@ocaml.deprecated "[since 2025-05] Use [Err.add_context]. Hint: Run [ocamlmig migrate]"]
 [@@migrate
   { repl =
       (fun error ~step ->
@@ -69,12 +81,3 @@ val init : Sexp.t -> step:Sexp.t -> t
           [ (Err.sexp step [@commutes]) ])
   ; libraries = [ "pplumbing.err" ]
   }]
-
-module Private : sig
-  module Non_raising_M : sig
-    type nonrec t = t [@@deriving sexp_of]
-
-    val to_err : t -> t
-    val of_err : t -> t
-  end
-end

--- a/lib/vcs/src/vcs_exn.ml
+++ b/lib/vcs/src/vcs_exn.ml
@@ -22,11 +22,3 @@
 let reraise_with_context err bt ~step =
   Err.reraise_with_context err bt [ Err.sexp step ] [@coverage off]
 ;;
-
-module Private = struct
-  let try_with f =
-    match f () with
-    | ok -> Ok ok
-    | exception exn -> Error (Err.of_exn exn)
-  ;;
-end

--- a/lib/vcs/src/vcs_exn.mli
+++ b/lib/vcs/src/vcs_exn.mli
@@ -28,20 +28,11 @@
 
 (** This is deprecated - use [Err.reraise_with_context] instead. *)
 val reraise_with_context : Err.t -> Printexc.raw_backtrace -> step:Sexp.t -> _
+[@@ocaml.deprecated
+  "[since 2025-05] Use [Err.reraise_with_context]. Hint: Run [ocamlmig migrate]"]
 [@@migrate
   { repl =
       (fun err bt ~step ->
         Err.reraise_with_context err bt [ (Err.sexp step [@commutes]) ])
   ; libraries = [ "pplumbing.err" ]
   }]
-
-module Private : sig
-  (** [try_with f] runs [f] and wraps any exception it raises into an
-      {!type:Err.t} error. Because this catches all exceptions, including
-      exceptions that may not be designed to be caught (such as
-      [Stack_overflow], [Out_of_memory], etc.) we recommend that code be
-      refactored overtime not to rely on this function. However, this is
-      rather hard to do without assistance from the type checker, thus we
-      currently rely on this function. TBD! *)
-  val try_with : (unit -> 'a) -> ('a, Err.t) Result.t
-end

--- a/lib/vcs/src/vcs_result.ml
+++ b/lib/vcs/src/vcs_result.ml
@@ -21,7 +21,15 @@
 
 open! Import
 
-type err = Vcs_err.t [@@deriving sexp_of]
+type err = Err.t [@@deriving sexp_of]
 type 'a t = ('a, err) Result.t [@@deriving sexp_of]
 
-include Non_raising.Make (Vcs_err.Private.Non_raising_M)
+module Non_raising_M = struct
+  type t = err
+
+  let sexp_of_t = Err.sexp_of_t
+  let to_err t = t
+  let of_err t = t
+end
+
+include Non_raising.Make (Non_raising_M)

--- a/lib/vcs_base/src/vcs_base.ml
+++ b/lib/vcs_base/src/vcs_base.ml
@@ -44,6 +44,8 @@ module Vcs = struct
   module User_handle = User_handle
   module User_name = User_name
 
+  [@@@ocaml.alert "-deprecated"]
+
   include (
     Vcs :
       module type of Vcs

--- a/lib/vcs_base/src/vcs_base.mli
+++ b/lib/vcs_base/src/vcs_base.mli
@@ -86,6 +86,8 @@ module Vcs : sig
   module User_handle = User_handle
   module User_name = User_name
 
+  [@@@ocaml.alert "-deprecated"]
+
   include
     module type of Vcs
     with module Author := Vcs.Author

--- a/lib/vcs_base/src/vcs_err.ml
+++ b/lib/vcs_base/src/vcs_err.ml
@@ -19,7 +19,7 @@
 (*  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*******************************************************************************)
 
-include Vcs.Err
+type t = Err.t
 
 let to_error t = Error.create_s (Err.sexp_of_t t)
 let of_error error = Err.create [ Err.sexp (Error.sexp_of_t error) ]

--- a/lib/vcs_base/src/vcs_err.mli
+++ b/lib/vcs_base/src/vcs_err.mli
@@ -21,8 +21,6 @@
 
 type t = Err.t
 
-include module type of Vcs.Err with type t := t
-
 (** Inject [t] into [Base.Error.t]. This is useful if you'd like to use [Vcs]
     inside the [Base.Or_error] monad. *)
 val to_error : t -> Error.t

--- a/lib/vcs_cli/src/dune
+++ b/lib/vcs_cli/src/dune
@@ -20,6 +20,7 @@
   fpath-sexp0
   pp
   pplumbing.err
+  pplumbing.pp-tty
   sexplib0
   unix
   vcs

--- a/lib/vcs_git_backend/src/dune
+++ b/lib/vcs_git_backend/src/dune
@@ -13,7 +13,15 @@
   Sexplib0
   -open
   Sexplib0.Sexp_conv)
- (libraries astring fpath fpath-sexp0 pp pplumbing.err pplumbing.pp-tty sexplib0 vcs)
+ (libraries
+  astring
+  fpath
+  fpath-sexp0
+  pp
+  pplumbing.err
+  pplumbing.pp-tty
+  sexplib0
+  vcs)
  (instrumentation
   (backend bisect_ppx))
  (lint

--- a/lib/vcs_git_backend/src/dune
+++ b/lib/vcs_git_backend/src/dune
@@ -13,7 +13,7 @@
   Sexplib0
   -open
   Sexplib0.Sexp_conv)
- (libraries astring fpath fpath-sexp0 pp pplumbing.err sexplib0 vcs)
+ (libraries astring fpath fpath-sexp0 pp pplumbing.err pplumbing.pp-tty sexplib0 vcs)
  (instrumentation
   (backend bisect_ppx))
  (lint

--- a/lib/vcs_git_backend/src/log.ml
+++ b/lib/vcs_git_backend/src/log.ml
@@ -23,7 +23,7 @@ open! Import
 
 let parse_log_line_exn ~line:str : Vcs.Log.Line.t =
   match
-    Vcs.Exn.Private.try_with (fun () ->
+    Vcs.Private.try_with (fun () ->
       match String.split (String.strip str) ~on:' ' with
       | [] -> assert false (* [String.split] never returns the empty list. *)
       | [ rev ] -> Vcs.Log.Line.Root { rev = Vcs.Rev.v rev }
@@ -60,7 +60,7 @@ module Make (Runtime : Runtime.S) = struct
       ~f:(fun output ->
         let open Result.Monad_syntax in
         let* output = Vcs.Git.Result.exit0_and_stdout output in
-        Vcs.Exn.Private.try_with (fun () ->
+        Vcs.Private.try_with (fun () ->
           List.map (String.split_lines output) ~f:(fun line -> parse_log_line_exn ~line)))
   ;;
 end

--- a/lib/vcs_git_backend/src/ls_files.ml
+++ b/lib/vcs_git_backend/src/ls_files.ml
@@ -32,7 +32,7 @@ module Make (Runtime : Runtime.S) = struct
       ~f:(fun output ->
         let open Result.Monad_syntax in
         let* stdout = Vcs.Git.Result.exit0_and_stdout output in
-        Vcs.Exn.Private.try_with (fun () ->
+        Vcs.Private.try_with (fun () ->
           String.split_lines stdout |> List.map ~f:Vcs.Path_in_repo.v))
   ;;
 end

--- a/lib/vcs_git_backend/src/munged_path.ml
+++ b/lib/vcs_git_backend/src/munged_path.ml
@@ -37,7 +37,7 @@ include T
 
 let parse_exn str =
   match
-    Vcs.Exn.Private.try_with (fun () ->
+    Vcs.Private.try_with (fun () ->
       match Astring.String.cuts ~empty:false ~sep:" => " str with
       | [] -> raise (Err.E (Err.create [ Pp.text "Unexpected empty path." ]))
       | [ str ] ->

--- a/lib/vcs_git_backend/src/name_status.ml
+++ b/lib/vcs_git_backend/src/name_status.ml
@@ -65,7 +65,7 @@ end
 
 let parse_line_exn ~line : Vcs.Name_status.Change.t =
   match
-    Vcs.Exn.Private.try_with (fun () ->
+    Vcs.Private.try_with (fun () ->
       match String.split line ~on:'\t' with
       | [] -> assert false
       | [ _ ] ->
@@ -125,7 +125,7 @@ module Make (Runtime : Runtime.S) = struct
       ~f:(fun output ->
         let open Result.Monad_syntax in
         let* stdout = Vcs.Git.Result.exit0_and_stdout output in
-        Vcs.Exn.Private.try_with (fun () ->
+        Vcs.Private.try_with (fun () ->
           parse_lines_exn ~lines:(String.split_lines stdout)))
   ;;
 end

--- a/lib/vcs_git_backend/src/num_status.ml
+++ b/lib/vcs_git_backend/src/num_status.ml
@@ -45,7 +45,7 @@ end
 
 let parse_line_exn ~line : Vcs.Num_status.Change.t =
   match
-    Vcs.Exn.Private.try_with (fun () ->
+    Vcs.Private.try_with (fun () ->
       match String.split line ~on:'\t' with
       | [] -> assert false
       | [ _ ] | [ _; _ ] | _ :: _ :: _ :: _ :: _ ->
@@ -97,7 +97,7 @@ module Make (Runtime : Runtime.S) = struct
       ~f:(fun output ->
         let open Result.Monad_syntax in
         let* stdout = Vcs.Git.Result.exit0_and_stdout output in
-        Vcs.Exn.Private.try_with (fun () ->
+        Vcs.Private.try_with (fun () ->
           parse_lines_exn ~lines:(String.split_lines stdout)))
   ;;
 end

--- a/lib/vcs_git_backend/src/refs.ml
+++ b/lib/vcs_git_backend/src/refs.ml
@@ -23,7 +23,7 @@ open! Import
 
 let parse_ref_kind_exn str : Vcs.Ref_kind.t =
   match
-    Vcs.Exn.Private.try_with (fun () ->
+    Vcs.Private.try_with (fun () ->
       let str =
         match String.chop_prefix str ~prefix:"refs/" with
         | Some str -> str
@@ -79,7 +79,7 @@ module Dereferenced = struct
 
   let parse_exn ~line:str =
     match
-      Vcs.Exn.Private.try_with (fun () ->
+      Vcs.Private.try_with (fun () ->
         match String.lsplit2 str ~on:' ' with
         | None -> raise (Err.E (Err.create [ Pp.text "Invalid ref line." ]))
         | Some (rev, ref_) ->
@@ -136,7 +136,7 @@ module Make (Runtime : Runtime.S) = struct
       ~f:(fun output ->
         let open Result.Monad_syntax in
         let* output = Vcs.Git.Result.exit0_and_stdout output in
-        Vcs.Exn.Private.try_with (fun () ->
+        Vcs.Private.try_with (fun () ->
           parse_lines_exn ~lines:(String.split_lines output)))
   ;;
 end

--- a/lib/vcs_git_eio/src/runtime.ml
+++ b/lib/vcs_git_eio/src/runtime.ml
@@ -35,18 +35,18 @@ let create ~env =
 
 let load_file t ~path =
   let path = Eio.Path.(t.fs / Absolute_path.to_string path) in
-  Vcs.Exn.Private.try_with (fun () -> Vcs.File_contents.create (Eio.Path.load path))
+  Vcs.Private.try_with (fun () -> Vcs.File_contents.create (Eio.Path.load path))
 ;;
 
 let save_file t ?(perms = 0o666) () ~path ~(file_contents : Vcs.File_contents.t) =
   let path = Eio.Path.(t.fs / Absolute_path.to_string path) in
-  Vcs.Exn.Private.try_with (fun () ->
+  Vcs.Private.try_with (fun () ->
     Eio.Path.save ~create:(`Or_truncate perms) path (file_contents :> string))
 ;;
 
 let read_dir t ~dir =
   let dir = Eio.Path.(t.fs / Absolute_path.to_string dir) in
-  Vcs.Exn.Private.try_with (fun () -> Eio.Path.read_dir dir |> List.map ~f:Fsegment.v)
+  Vcs.Private.try_with (fun () -> Eio.Path.read_dir dir |> List.map ~f:Fsegment.v)
 ;;
 
 (* The modules [Exit_status], [Lines] and the function [git] below are derived

--- a/lib/vcs_git_unix/src/dune
+++ b/lib/vcs_git_unix/src/dune
@@ -18,6 +18,7 @@
   fpath-sexp0
   pp
   pplumbing.err
+  pplumbing.pp-tty
   shexp.process
   unix
   vcs

--- a/lib/vcs_git_unix/src/runtime.ml
+++ b/lib/vcs_git_unix/src/runtime.ml
@@ -55,13 +55,13 @@ let create () =
 ;;
 
 let load_file (_ : t) ~path =
-  Vcs.Exn.Private.try_with (fun () ->
+  Vcs.Private.try_with (fun () ->
     In_channel.with_open_bin (Absolute_path.to_string path) In_channel.input_all
     |> Vcs.File_contents.create)
 ;;
 
 let save_file (_ : t) ?(perms = 0o666) () ~path ~(file_contents : Vcs.File_contents.t) =
-  Vcs.Exn.Private.try_with (fun () ->
+  Vcs.Private.try_with (fun () ->
     let oc =
       open_out_gen
         [ Open_wronly; Open_creat; Open_trunc; Open_binary ]
@@ -74,7 +74,7 @@ let save_file (_ : t) ?(perms = 0o666) () ~path ~(file_contents : Vcs.File_conte
 ;;
 
 let read_dir (_ : t) ~dir =
-  Vcs.Exn.Private.try_with (fun () ->
+  Vcs.Private.try_with (fun () ->
     let entries = Sys.readdir (Absolute_path.to_string dir) in
     Array.sort entries ~compare:String.compare;
     entries |> Array.map ~f:Fsegment.v |> Array.to_list)

--- a/vcs-git-backend.opam
+++ b/vcs-git-backend.opam
@@ -9,16 +9,16 @@ doc: "https://mbarbin.github.io/vcs/"
 bug-reports: "https://github.com/mbarbin/vcs/issues"
 depends: [
   "dune" {>= "3.17"}
-  "ocaml" {>= "5.2"}
+  "ocaml" {>= "4.14"}
   "astring" {>= "0.8.5"}
   "fpath" {>= "0.7.3"}
   "fpath-sexp0" {>= "0.2.2"}
   "pp" {>= "2.0.0"}
   "pplumbing" {>= "0.0.13"}
-  "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
-  "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv" {>= "v0.16"}
+  "ppx_sexp_value" {>= "v0.16"}
   "ppxlib" {>= "0.33"}
-  "sexplib0" {>= "v0.17" & < "v0.18"}
+  "sexplib0" {>= "v0.16"}
   "vcs" {= version}
   "odoc" {with-doc}
 ]

--- a/vcs-git-unix.opam
+++ b/vcs-git-unix.opam
@@ -10,16 +10,16 @@ doc: "https://mbarbin.github.io/vcs/"
 bug-reports: "https://github.com/mbarbin/vcs/issues"
 depends: [
   "dune" {>= "3.17"}
-  "ocaml" {>= "5.2"}
+  "ocaml" {>= "4.14"}
   "fpath" {>= "0.7.3"}
   "fpath-sexp0" {>= "0.2.2"}
   "pp" {>= "2.0.0"}
   "pplumbing" {>= "0.0.13"}
-  "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
-  "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
+  "ppx_sexp_conv" {>= "v0.16"}
+  "ppx_sexp_value" {>= "v0.16"}
   "ppxlib" {>= "0.33"}
-  "sexplib0" {>= "v0.17" & < "v0.18"}
-  "shexp" {>= "v0.17" & < "v0.18"}
+  "sexplib0" {>= "v0.16"}
+  "shexp" {>= "v0.16"}
   "vcs" {= version}
   "vcs-git-backend" {= version}
   "odoc" {with-doc}

--- a/vcs.opam
+++ b/vcs.opam
@@ -9,15 +9,15 @@ doc: "https://mbarbin.github.io/vcs/"
 bug-reports: "https://github.com/mbarbin/vcs/issues"
 depends: [
   "dune" {>= "3.17"}
-  "ocaml" {>= "5.2"}
+  "ocaml" {>= "4.14"}
   "astring" {>= "0.8.5"}
   "fpath" {>= "0.7.3"}
   "fpath-sexp0" {>= "0.2.2"}
   "pp" {>= "2.0.0"}
   "pplumbing" {>= "0.0.13"}
-  "ppx_enumerate" {>= "v0.17" & < "v0.18"}
-  "ppx_sexp_conv" {>= "v0.17" & < "v0.18"}
-  "ppx_sexp_value" {>= "v0.17" & < "v0.18"}
+  "ppx_enumerate" {>= "v0.16"}
+  "ppx_sexp_conv" {>= "v0.16"}
+  "ppx_sexp_value" {>= "v0.16"}
   "ppxlib" {>= "0.33"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
- Add support for OCaml-4.14 to `vcs`, `vcs-git-unix`.
- Actually mark for deprecation all the functions, modules and exceptions that were prepared to be deprecated in the previous release.