### PR TITLE
Improve tests stability

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,12 +6,15 @@
 
 ### Changed
 
+- Set `prog` to the executable basename in error context for stability (#77, @mbarbin).
 - Replace `shexp` by direct use of `spawn` (#76, @mbarbin).
 
 ### Deprecated
 
 ### Fixed
 
+- Make `hg` more silent during tests for stability (#77, @mbarbin).
+- Require `5.3` for `volgo-dev` for stability (#77, @mbarbin).
 - Fix build with OCaml `5.0` (#73, @mbarbin).
 
 ### Removed

--- a/dune-project
+++ b/dune-project
@@ -96,9 +96,9 @@
  (depends
   (ocaml
    (>= 4.14))
-  (conf-git :with-test)
   (cmdlang
    (>= 0.0.9))
+  (conf-git :with-test)
   (fpath
    (>= 0.7.3))
   (fpath-sexp0

--- a/dune-project
+++ b/dune-project
@@ -448,7 +448,7 @@
  (allow_empty) ; The package is attached to stanza in doc/ however dune doesn't see it.
  (depends
   (ocaml
-   (>= 5.2))
+   (>= 5.3))
   (ocamlformat
    (and
     :with-dev-setup

--- a/lib/volgo_git_unix/src/make_runtime.ml
+++ b/lib/volgo_git_unix/src/make_runtime.ml
@@ -251,7 +251,7 @@ let vcs_cli ~of_process_output ?env t ~cwd ~args ~f =
          err
          [ Err.sexp
              [%sexp
-               { prog : string
+               { prog = (executable_basename : string)
                ; args : string list
                ; exit_status = (!exit_status_r : Exit_status.t)
                ; cwd : Absolute_path.t

--- a/lib/volgo_hg_unix/test/test__hello_cli.ml
+++ b/lib/volgo_hg_unix/test/test__hello_cli.ml
@@ -88,13 +88,13 @@ let%expect_test "hello cli" =
       print_s
         (Vcs_test_helpers.redact_sexp
            [%sexp (err : Err.t)]
-           ~fields:[ "cwd"; "repo_root"; "stderr" ])
+           ~fields:[ "cwd"; "prog"; "repo_root"; "stderr" ])
   in
   [%expect
     {|
     ((context
        (Vcs.hg ((repo_root <REDACTED>) (args (bogus))))
-       ((prog /usr/bin/hg)
+       ((prog <REDACTED>)
         (args (bogus))
         (exit_status (Exited 255))
         (cwd    <REDACTED>)
@@ -109,13 +109,13 @@ let%expect_test "hello cli" =
       print_s
         (Vcs_test_helpers.redact_sexp
            [%sexp (err : Err.t)]
-           ~fields:[ "cwd"; "repo_root"; "stderr" ])
+           ~fields:[ "cwd"; "prog"; "repo_root"; "stderr" ])
   in
   [%expect
     {|
     ((context
        (Vcs.hg ((repo_root <REDACTED>) (args (bogus))))
-       ((prog /usr/bin/hg)
+       ((prog <REDACTED>)
         (args (bogus))
         (exit_status (Exited 255))
         (cwd    <REDACTED>)

--- a/test/cram/run-hg.t
+++ b/test/cram/run-hg.t
@@ -1,7 +1,7 @@
 First we need to setup a repo in a way that satisfies the test environment. This
 includes specifics required by the GitHub Actions environment.
 
-  $ hg init
+  $ hg init 2> /dev/null
 
   $ cat > hello << EOF
   > Hello World
@@ -15,7 +15,7 @@ includes specifics required by the GitHub Actions environment.
 
 Rev-parse.
 
-  $ hg log -r . --template "{node}\n" | sed -e "s/$rev0/rev0/g"
+  $ hg log -r . --template "{node}\n" 2> /dev/null | sed -e "s/$rev0/rev0/g"
   rev0
 
   $ volgo-vcs current-revision | sed -e "s/$rev0/rev0/g"
@@ -48,22 +48,12 @@ Adding a new file under a directory.
   Error: Path is not in repo. (path /dir)
   [123]
 
-  $ volgo-vcs ls-files --below foo
-  Context:
-  (Vcs.ls_files
-   (repo_root
-    $TESTCASE_ROOT)
-   (below foo))
-  ((prog hg) (args (files --include ./foo/)) (exit_status (Exited 1))
-   (cwd
-    $TESTCASE_ROOT)
-   (stdout "") (stderr ""))
-  Error: Expected exit code 0.
+  $ volgo-vcs ls-files --below foo 2> /dev/null
   [123]
 
 Vcs allows to run the git command line directly if the backend supports it.
 
-  $ volgo-vcs hg -- log -r . --template "{node}" | sed -e "s/$rev1/rev1/g"
+  $ volgo-vcs hg -- log -r . --template "{node}" 2> /dev/null | sed -e "s/$rev1/rev1/g"
   rev1
 
   $ volgo-vcs hg invalid-command 2> /dev/null

--- a/test/cram/run-hg.t
+++ b/test/cram/run-hg.t
@@ -54,7 +54,7 @@ Adding a new file under a directory.
    (repo_root
     $TESTCASE_ROOT)
    (below foo))
-  ((prog /usr/bin/hg) (args (files --include ./foo/)) (exit_status (Exited 1))
+  ((prog hg) (args (files --include ./foo/)) (exit_status (Exited 1))
    (cwd
     $TESTCASE_ROOT)
    (stdout "") (stderr ""))

--- a/test/cram/run.t
+++ b/test/cram/run.t
@@ -151,7 +151,7 @@ Adding a new file under a directory.
    (repo_root
     $TESTCASE_ROOT)
    (below foo))
-  ((prog /usr/bin/git) (args (ls-files --full-name)) (exit_status Unknown)
+  ((prog git) (args (ls-files --full-name)) (exit_status Unknown)
    (cwd
     $TESTCASE_ROOT/foo)
    (stdout "") (stderr ""))

--- a/volgo-dev.opam
+++ b/volgo-dev.opam
@@ -10,7 +10,7 @@ doc: "https://mbarbin.github.io/vcs/"
 bug-reports: "https://github.com/mbarbin/vcs/issues"
 depends: [
   "dune" {>= "3.17"}
-  "ocaml" {>= "5.2"}
+  "ocaml" {>= "5.3"}
   "ocamlformat" {with-dev-setup & = "0.27.0"}
   "astring" {>= "0.8.5"}
   "base" {>= "v0.17"}

--- a/volgo-vcs.opam
+++ b/volgo-vcs.opam
@@ -11,8 +11,8 @@ bug-reports: "https://github.com/mbarbin/vcs/issues"
 depends: [
   "dune" {>= "3.17"}
   "ocaml" {>= "4.14"}
-  "conf-git" {with-test}
   "cmdlang" {>= "0.0.9"}
+  "conf-git" {with-test}
   "fpath" {>= "0.7.3"}
   "fpath-sexp0" {>= "0.3.1"}
   "pp" {>= "2.0.0"}


### PR DESCRIPTION
Some assorted changes to make the tests less brittle when run in various os/os-distribution context.

Also forces the latest version of OCaml (same as used in main CI) for the volgo-dev target, to ease maintenance.