### PR TITLE
Split trait rev_parse into { current branch ; current_revision }

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 
 ### Changed
 
+- Split trait `rev_parse` into two smaller traits (#80, @mbarbin).
 - Set `prog` to the executable basename in error context for stability (#77, @mbarbin).
 - Replace `shexp` by direct use of `spawn` (#76, @mbarbin).
 
@@ -20,6 +21,7 @@
 
 ### Removed
 
+- Remove trait `rev_parse` (#80, @mbarbin).
 - Replace `Vcs.Url` by the more complete `Vcs.Platform_repo` module (#78, @mbarbin).
 
 ## 0.0.17 (2025-06-05)

--- a/lib/volgo/src/trait.ml
+++ b/lib/volgo/src/trait.ml
@@ -29,6 +29,8 @@ module Add = Trait_add
 module Branch = Trait_branch
 module Commit = Trait_commit
 module Config = Trait_config
+module Current_branch = Trait_current_branch
+module Current_revision = Trait_current_revision
 module File_system = Trait_file_system
 module Git = Trait_git
 module Hg = Trait_hg
@@ -38,13 +40,14 @@ module Ls_files = Trait_ls_files
 module Name_status = Trait_name_status
 module Num_status = Trait_num_status
 module Refs = Trait_refs
-module Rev_parse = Trait_rev_parse
 module Show = Trait_show
 
 class type add = Add.t
 class type branch = Branch.t
 class type commit = Commit.t
 class type config = Config.t
+class type current_branch = Current_branch.t
+class type current_revision = Current_revision.t
 class type file_system = File_system.t
 class type git = Git.t
 class type hg = Hg.t
@@ -54,7 +57,6 @@ class type ls_files = Ls_files.t
 class type name_status = Name_status.t
 class type num_status = Num_status.t
 class type refs = Refs.t
-class type rev_parse = Rev_parse.t
 class type show = Show.t
 
 class type t = object
@@ -62,6 +64,8 @@ class type t = object
   inherit branch
   inherit commit
   inherit config
+  inherit current_branch
+  inherit current_revision
   inherit file_system
   inherit git
   inherit hg
@@ -71,7 +75,6 @@ class type t = object
   inherit name_status
   inherit num_status
   inherit refs
-  inherit rev_parse
   inherit show
 end
 
@@ -113,6 +116,16 @@ class unimplemented : t =
 
     method set_user_email ~repo_root:_ ~user_email:_ =
       unimplemented ~trait:"Vcs.Trait.config" ~method_:"set_user_email"
+
+    (* current_branch *)
+
+    method current_branch ~repo_root:_ =
+      unimplemented ~trait:"Vcs.Trait.current_branch" ~method_:"current_branch"
+
+    (* current_revision *)
+
+    method current_revision ~repo_root:_ =
+      unimplemented ~trait:"Vcs.Trait.current_revision" ~method_:"current_revision"
 
     (* file_system *)
 
@@ -178,14 +191,6 @@ class unimplemented : t =
 
     method show_ref ~repo_root:_ =
       unimplemented ~trait:"Vcs.Trait.refs" ~method_:"show_ref"
-
-    (* rev_parse *)
-
-    method current_branch ~repo_root:_ =
-      unimplemented ~trait:"Vcs.Trait.rev_parse" ~method_:"current_branch"
-
-    method current_revision ~repo_root:_ =
-      unimplemented ~trait:"Vcs.Trait.rev_parse" ~method_:"current_revision"
 
     (* show *)
 

--- a/lib/volgo/src/trait.mli
+++ b/lib/volgo/src/trait.mli
@@ -89,6 +89,30 @@ module Config : sig
   end
 end
 
+class type current_branch = Trait_current_branch.t
+
+module Current_branch : sig
+  module type S = Trait_current_branch.S
+
+  module Make (X : S) : sig
+    class c : X.t -> object
+      inherit current_branch
+    end
+  end
+end
+
+class type current_revision = Trait_current_revision.t
+
+module Current_revision : sig
+  module type S = Trait_current_revision.S
+
+  module Make (X : S) : sig
+    class c : X.t -> object
+      inherit current_revision
+    end
+  end
+end
+
 class type file_system = Trait_file_system.t
 
 module File_system : sig
@@ -197,18 +221,6 @@ module Refs : sig
   end
 end
 
-class type rev_parse = Trait_rev_parse.t
-
-module Rev_parse : sig
-  module type S = Trait_rev_parse.S
-
-  module Make (X : S) : sig
-    class c : X.t -> object
-      inherit rev_parse
-    end
-  end
-end
-
 class type show = Trait_show.t
 
 module Show : sig
@@ -227,6 +239,8 @@ class type t = object
   inherit branch
   inherit commit
   inherit config
+  inherit current_branch
+  inherit current_revision
   inherit file_system
   inherit git
   inherit hg
@@ -236,7 +250,6 @@ class type t = object
   inherit name_status
   inherit num_status
   inherit refs
-  inherit rev_parse
   inherit show
 end
 

--- a/lib/volgo/src/trait_current_branch.ml
+++ b/lib/volgo/src/trait_current_branch.ml
@@ -1,0 +1,39 @@
+(*******************************************************************************)
+(*  Volgo - a Versatile OCaml Library for Git Operations                       *)
+(*  Copyright (C) 2024-2025 Mathieu Barbin <mathieu.barbin@gmail.com>          *)
+(*                                                                             *)
+(*  This file is part of Volgo.                                                *)
+(*                                                                             *)
+(*  Volgo is free software; you can redistribute it and/or modify it under     *)
+(*  the terms of the GNU Lesser General Public License as published by the     *)
+(*  Free Software Foundation either version 3 of the License, or any later     *)
+(*  version, with the LGPL-3.0 Linking Exception.                              *)
+(*                                                                             *)
+(*  Volgo is distributed in the hope that it will be useful, but WITHOUT ANY   *)
+(*  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS  *)
+(*  FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License and    *)
+(*  the file `NOTICE.md` at the root of this repository for more details.      *)
+(*                                                                             *)
+(*  You should have received a copy of the GNU Lesser General Public License   *)
+(*  and the LGPL-3.0 Linking Exception along with this library. If not, see    *)
+(*  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
+(*******************************************************************************)
+
+type current_branch_method = repo_root:Repo_root.t -> (Branch_name.t, Err.t) Result.t
+
+module type S = sig
+  type t
+
+  val current_branch : t -> current_branch_method
+end
+
+class type t = object
+  method current_branch : current_branch_method
+end
+
+module Make (X : S) = struct
+  class c (t : X.t) =
+    object
+      method current_branch = X.current_branch t
+    end
+end

--- a/lib/volgo/src/trait_current_branch.mli
+++ b/lib/volgo/src/trait_current_branch.mli
@@ -1,0 +1,38 @@
+(*_******************************************************************************)
+(*_  Volgo - a Versatile OCaml Library for Git Operations                       *)
+(*_  Copyright (C) 2024-2025 Mathieu Barbin <mathieu.barbin@gmail.com>          *)
+(*_                                                                             *)
+(*_  This file is part of Volgo.                                                *)
+(*_                                                                             *)
+(*_  Volgo is free software; you can redistribute it and/or modify it under     *)
+(*_  the terms of the GNU Lesser General Public License as published by the     *)
+(*_  Free Software Foundation either version 3 of the License, or any later     *)
+(*_  version, with the LGPL-3.0 Linking Exception.                              *)
+(*_                                                                             *)
+(*_  Volgo is distributed in the hope that it will be useful, but WITHOUT ANY   *)
+(*_  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS  *)
+(*_  FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License and    *)
+(*_  the file `NOTICE.md` at the root of this repository for more details.      *)
+(*_                                                                             *)
+(*_  You should have received a copy of the GNU Lesser General Public License   *)
+(*_  and the LGPL-3.0 Linking Exception along with this library. If not, see    *)
+(*_  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
+(*_******************************************************************************)
+
+type current_branch_method = repo_root:Repo_root.t -> (Branch_name.t, Err.t) Result.t
+
+module type S = sig
+  type t
+
+  val current_branch : t -> current_branch_method
+end
+
+class type t = object
+  method current_branch : current_branch_method
+end
+
+module Make (X : S) : sig
+  class c : X.t -> object
+    inherit t
+  end
+end

--- a/lib/volgo/src/trait_current_revision.ml
+++ b/lib/volgo/src/trait_current_revision.ml
@@ -1,0 +1,39 @@
+(*******************************************************************************)
+(*  Volgo - a Versatile OCaml Library for Git Operations                       *)
+(*  Copyright (C) 2024-2025 Mathieu Barbin <mathieu.barbin@gmail.com>          *)
+(*                                                                             *)
+(*  This file is part of Volgo.                                                *)
+(*                                                                             *)
+(*  Volgo is free software; you can redistribute it and/or modify it under     *)
+(*  the terms of the GNU Lesser General Public License as published by the     *)
+(*  Free Software Foundation either version 3 of the License, or any later     *)
+(*  version, with the LGPL-3.0 Linking Exception.                              *)
+(*                                                                             *)
+(*  Volgo is distributed in the hope that it will be useful, but WITHOUT ANY   *)
+(*  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS  *)
+(*  FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License and    *)
+(*  the file `NOTICE.md` at the root of this repository for more details.      *)
+(*                                                                             *)
+(*  You should have received a copy of the GNU Lesser General Public License   *)
+(*  and the LGPL-3.0 Linking Exception along with this library. If not, see    *)
+(*  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
+(*******************************************************************************)
+
+type current_revision_method = repo_root:Repo_root.t -> (Rev.t, Err.t) Result.t
+
+module type S = sig
+  type t
+
+  val current_revision : t -> current_revision_method
+end
+
+class type t = object
+  method current_revision : current_revision_method
+end
+
+module Make (X : S) = struct
+  class c (t : X.t) =
+    object
+      method current_revision = X.current_revision t
+    end
+end

--- a/lib/volgo/src/trait_current_revision.mli
+++ b/lib/volgo/src/trait_current_revision.mli
@@ -19,8 +19,20 @@
 (*_  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*_******************************************************************************)
 
-module Make (Runtime : Runtime.S) : sig
-  type t = Runtime.t
+type current_revision_method = repo_root:Repo_root.t -> (Rev.t, Err.t) Result.t
 
-  include Vcs.Trait.Rev_parse.S with type t := t
+module type S = sig
+  type t
+
+  val current_revision : t -> current_revision_method
+end
+
+class type t = object
+  method current_revision : current_revision_method
+end
+
+module Make (X : S) : sig
+  class c : X.t -> object
+    inherit t
+  end
 end

--- a/lib/volgo/src/vcs.mli
+++ b/lib/volgo/src/vcs.mli
@@ -132,7 +132,7 @@ val add : < Trait.add ; .. > t -> repo_root:Repo_root.t -> path:Path_in_repo.t -
 
 (** When this succeeds, this returns the revision of the commit that was just created. *)
 val commit
-  :  < Trait.rev_parse ; Trait.commit ; .. > t
+  :  < Trait.commit ; Trait.current_revision ; .. > t
   -> repo_root:Repo_root.t
   -> commit_message:Commit_message.t
   -> Rev.t
@@ -222,10 +222,14 @@ val log : < Trait.log ; .. > t -> repo_root:Repo_root.t -> Log.t
 val refs : < Trait.refs ; .. > t -> repo_root:Repo_root.t -> Refs.t
 val graph : < Trait.log ; Trait.refs ; .. > t -> repo_root:Repo_root.t -> Graph.t
 
-(** {1 Rev parse utils} *)
+(** {1 Current branch & revision} *)
 
-val current_branch : < Trait.rev_parse ; .. > t -> repo_root:Repo_root.t -> Branch_name.t
-val current_revision : < Trait.rev_parse ; .. > t -> repo_root:Repo_root.t -> Rev.t
+val current_branch
+  :  < Trait.current_branch ; .. > t
+  -> repo_root:Repo_root.t
+  -> Branch_name.t
+
+val current_revision : < Trait.current_revision ; .. > t -> repo_root:Repo_root.t -> Rev.t
 
 (** {1 User config} *)
 

--- a/lib/volgo/src/vcs0.ml
+++ b/lib/volgo/src/vcs0.ml
@@ -86,17 +86,21 @@ let find_enclosing_git_repo_root t ~from =
   | Some (`Git, repo_root) -> Some repo_root
 ;;
 
-let current_branch (t : < Trait.rev_parse ; .. > t) ~repo_root =
+let current_branch (t : < Trait.current_branch ; .. > t) ~repo_root =
   t#current_branch ~repo_root
   |> of_result ~step:(lazy [%sexp "Vcs.current_branch", { repo_root : Repo_root.t }])
 ;;
 
-let current_revision (t : < Trait.rev_parse ; .. > t) ~repo_root =
+let current_revision (t : < Trait.current_revision ; .. > t) ~repo_root =
   t#current_revision ~repo_root
   |> of_result ~step:(lazy [%sexp "Vcs.current_revision", { repo_root : Repo_root.t }])
 ;;
 
-let commit (t : < Trait.rev_parse ; Trait.commit ; .. > t) ~repo_root ~commit_message =
+let commit
+      (t : < Trait.commit ; Trait.current_revision ; .. > t)
+      ~repo_root
+      ~commit_message
+  =
   (let open Result.Monad_syntax in
    let* () = t#commit ~repo_root ~commit_message in
    t#current_revision ~repo_root)

--- a/lib/volgo/src/vcs_intf.mli
+++ b/lib/volgo/src/vcs_intf.mli
@@ -56,18 +56,18 @@ module type S = sig
     -> unit result
 
   val commit
-    :  < Trait.rev_parse ; Trait.commit ; .. > t
+    :  < Trait.commit ; Trait.current_revision ; .. > t
     -> repo_root:Repo_root.t
     -> commit_message:Commit_message.t
     -> Rev.t result
 
   val current_branch
-    :  < Trait.rev_parse ; .. > t
+    :  < Trait.current_branch ; .. > t
     -> repo_root:Repo_root.t
     -> Branch_name.t result
 
   val current_revision
-    :  < Trait.rev_parse ; .. > t
+    :  < Trait.current_revision ; .. > t
     -> repo_root:Repo_root.t
     -> Rev.t result
 

--- a/lib/volgo/test/test__trait.ml
+++ b/lib/volgo/test/test__trait.ml
@@ -82,6 +82,22 @@ let%expect_test "unimplemented" =
      (error
       "Trait [Vcs.Trait.config] method [set_user_email] is not available in this repository."))
     |}];
+  (* current_branch *)
+  test (fun () -> Vcs.current_branch vcs ~repo_root);
+  [%expect
+    {|
+    ((context (Vcs.current_branch ((repo_root /path/to/repo))))
+     (error
+      "Trait [Vcs.Trait.current_branch] method [current_branch] is not available in this repository."))
+    |}];
+  (* current_revision *)
+  test (fun () -> Vcs.current_revision vcs ~repo_root);
+  [%expect
+    {|
+    ((context (Vcs.current_revision ((repo_root /path/to/repo))))
+     (error
+      "Trait [Vcs.Trait.current_revision] method [current_revision] is not available in this repository."))
+    |}];
   (* file_system *)
   test (fun () -> Vcs.load_file vcs ~path:(Absolute_path.v "/path/to/file"));
   [%expect
@@ -188,21 +204,6 @@ let%expect_test "unimplemented" =
     ((context (Vcs.refs ((repo_root /path/to/repo))))
      (error
       "Trait [Vcs.Trait.refs] method [show_ref] is not available in this repository."))
-    |}];
-  (* rev_parse *)
-  test (fun () -> Vcs.current_branch vcs ~repo_root);
-  [%expect
-    {|
-    ((context (Vcs.current_branch ((repo_root /path/to/repo))))
-     (error
-      "Trait [Vcs.Trait.current_branch] method [current_branch] is not available in this repository."))
-    |}];
-  test (fun () -> Vcs.current_revision vcs ~repo_root);
-  [%expect
-    {|
-    ((context (Vcs.current_revision ((repo_root /path/to/repo))))
-     (error
-      "Trait [Vcs.Trait.current_revision] method [current_revision] is not available in this repository."))
     |}];
   (* show *)
   test (fun () ->

--- a/lib/volgo/test/test__trait.ml
+++ b/lib/volgo/test/test__trait.ml
@@ -195,14 +195,14 @@ let%expect_test "unimplemented" =
     {|
     ((context (Vcs.current_branch ((repo_root /path/to/repo))))
      (error
-      "Trait [Vcs.Trait.rev_parse] method [current_branch] is not available in this repository."))
+      "Trait [Vcs.Trait.current_branch] method [current_branch] is not available in this repository."))
     |}];
   test (fun () -> Vcs.current_revision vcs ~repo_root);
   [%expect
     {|
     ((context (Vcs.current_revision ((repo_root /path/to/repo))))
      (error
-      "Trait [Vcs.Trait.rev_parse] method [current_revision] is not available in this repository."))
+      "Trait [Vcs.Trait.current_revision] method [current_revision] is not available in this repository."))
     |}];
   (* show *)
   test (fun () ->

--- a/lib/volgo_git_backend/src/current_branch.ml
+++ b/lib/volgo_git_backend/src/current_branch.ml
@@ -36,17 +36,4 @@ module Make (Runtime : Runtime.S) = struct
         | Ok _ as ok -> ok
         | Error (`Msg m) -> Error (Err.create [ Pp.text m ]) [@coverage off])
   ;;
-
-  let current_revision t ~repo_root =
-    Runtime.git
-      t
-      ~cwd:(repo_root |> Vcs.Repo_root.to_absolute_path)
-      ~args:[ "rev-parse"; "--verify"; "HEAD^{commit}" ]
-      ~f:(fun output ->
-        let open Result.Monad_syntax in
-        let* stdout = Vcs.Git.Result.exit0_and_stdout output in
-        match Vcs.Rev.of_string (String.strip stdout) with
-        | Ok _ as ok -> ok
-        | Error (`Msg m) -> Error (Err.create [ Pp.text m ]) [@coverage off])
-  ;;
 end

--- a/lib/volgo_git_backend/src/current_branch.mli
+++ b/lib/volgo_git_backend/src/current_branch.mli
@@ -22,5 +22,5 @@
 module Make (Runtime : Runtime.S) : sig
   type t = Runtime.t
 
-  include Vcs.Trait.Rev_parse.S with type t := t
+  include Vcs.Trait.Current_branch.S with type t := t
 end

--- a/lib/volgo_git_backend/src/current_revision.ml
+++ b/lib/volgo_git_backend/src/current_revision.ml
@@ -1,0 +1,39 @@
+(*******************************************************************************)
+(*  Volgo - a Versatile OCaml Library for Git Operations                       *)
+(*  Copyright (C) 2024-2025 Mathieu Barbin <mathieu.barbin@gmail.com>          *)
+(*                                                                             *)
+(*  This file is part of Volgo.                                                *)
+(*                                                                             *)
+(*  Volgo is free software; you can redistribute it and/or modify it under     *)
+(*  the terms of the GNU Lesser General Public License as published by the     *)
+(*  Free Software Foundation either version 3 of the License, or any later     *)
+(*  version, with the LGPL-3.0 Linking Exception.                              *)
+(*                                                                             *)
+(*  Volgo is distributed in the hope that it will be useful, but WITHOUT ANY   *)
+(*  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS  *)
+(*  FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License and    *)
+(*  the file `NOTICE.md` at the root of this repository for more details.      *)
+(*                                                                             *)
+(*  You should have received a copy of the GNU Lesser General Public License   *)
+(*  and the LGPL-3.0 Linking Exception along with this library. If not, see    *)
+(*  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
+(*******************************************************************************)
+
+open! Import
+
+module Make (Runtime : Runtime.S) = struct
+  type t = Runtime.t
+
+  let current_revision t ~repo_root =
+    Runtime.git
+      t
+      ~cwd:(repo_root |> Vcs.Repo_root.to_absolute_path)
+      ~args:[ "rev-parse"; "--verify"; "HEAD^{commit}" ]
+      ~f:(fun output ->
+        let open Result.Monad_syntax in
+        let* stdout = Vcs.Git.Result.exit0_and_stdout output in
+        match Vcs.Rev.of_string (String.strip stdout) with
+        | Ok _ as ok -> ok
+        | Error (`Msg m) -> Error (Err.create [ Pp.text m ]) [@coverage off])
+  ;;
+end

--- a/lib/volgo_git_backend/src/current_revision.mli
+++ b/lib/volgo_git_backend/src/current_revision.mli
@@ -1,0 +1,26 @@
+(*_******************************************************************************)
+(*_  Volgo - a Versatile OCaml Library for Git Operations                       *)
+(*_  Copyright (C) 2024-2025 Mathieu Barbin <mathieu.barbin@gmail.com>          *)
+(*_                                                                             *)
+(*_  This file is part of Volgo.                                                *)
+(*_                                                                             *)
+(*_  Volgo is free software; you can redistribute it and/or modify it under     *)
+(*_  the terms of the GNU Lesser General Public License as published by the     *)
+(*_  Free Software Foundation either version 3 of the License, or any later     *)
+(*_  version, with the LGPL-3.0 Linking Exception.                              *)
+(*_                                                                             *)
+(*_  Volgo is distributed in the hope that it will be useful, but WITHOUT ANY   *)
+(*_  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS  *)
+(*_  FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License and    *)
+(*_  the file `NOTICE.md` at the root of this repository for more details.      *)
+(*_                                                                             *)
+(*_  You should have received a copy of the GNU Lesser General Public License   *)
+(*_  and the LGPL-3.0 Linking Exception along with this library. If not, see    *)
+(*_  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
+(*_******************************************************************************)
+
+module Make (Runtime : Runtime.S) : sig
+  type t = Runtime.t
+
+  include Vcs.Trait.Current_revision.S with type t := t
+end

--- a/lib/volgo_git_backend/src/volgo_git_backend.ml
+++ b/lib/volgo_git_backend/src/volgo_git_backend.ml
@@ -23,13 +23,14 @@ module Add = Add
 module Branch = Branch
 module Commit = Commit
 module Config = Config
+module Current_branch = Current_branch
+module Current_revision = Current_revision
 module Init = Init
 module Log = Log
 module Ls_files = Ls_files
 module Name_status = Name_status
 module Num_status = Num_status
 module Refs = Refs
-module Rev_parse = Rev_parse
 module Runtime = Runtime
 module Show = Show
 
@@ -43,6 +44,8 @@ module Trait = struct
     inherit Vcs.Trait.branch
     inherit Vcs.Trait.commit
     inherit Vcs.Trait.config
+    inherit Vcs.Trait.current_branch
+    inherit Vcs.Trait.current_revision
     inherit Vcs.Trait.file_system
     inherit Vcs.Trait.git
     inherit Vcs.Trait.init
@@ -51,7 +54,6 @@ module Trait = struct
     inherit Vcs.Trait.name_status
     inherit Vcs.Trait.num_status
     inherit Vcs.Trait.refs
-    inherit Vcs.Trait.rev_parse
     inherit Vcs.Trait.show
   end
 end
@@ -65,6 +67,8 @@ module type S = sig
   module Branch : Vcs.Trait.Branch.S with type t = t
   module Commit : Vcs.Trait.Commit.S with type t = t
   module Config : Vcs.Trait.Config.S with type t = t
+  module Current_branch : Vcs.Trait.Current_branch.S with type t = t
+  module Current_revision : Vcs.Trait.Current_revision.S with type t = t
   module File_system : Vcs.Trait.File_system.S with type t = t
   module Git : Vcs.Trait.Git.S with type t = t
   module Init : Vcs.Trait.Init.S with type t = t
@@ -73,7 +77,6 @@ module type S = sig
   module Name_status : Vcs.Trait.Name_status.S with type t = t
   module Num_status : Vcs.Trait.Num_status.S with type t = t
   module Refs : Vcs.Trait.Refs.S with type t = t
-  module Rev_parse : Vcs.Trait.Rev_parse.S with type t = t
   module Show : Vcs.Trait.Show.S with type t = t
 end
 
@@ -85,6 +88,8 @@ module Make (Runtime : Runtime.S) = struct
     module Branch = Branch.Make (Runtime)
     module Commit = Commit.Make (Runtime)
     module Config = Config.Make (Runtime)
+    module Current_branch = Current_branch.Make (Runtime)
+    module Current_revision = Current_revision.Make (Runtime)
     module File_system = Runtime
     module Git = Runtime
     module Init = Init.Make (Runtime)
@@ -93,7 +98,6 @@ module Make (Runtime : Runtime.S) = struct
     module Name_status = Name_status.Make (Runtime)
     module Num_status = Num_status.Make (Runtime)
     module Refs = Refs.Make (Runtime)
-    module Rev_parse = Rev_parse.Make (Runtime)
     module Show = Show.Make (Runtime)
   end
 
@@ -102,6 +106,8 @@ module Make (Runtime : Runtime.S) = struct
     module Branch = Vcs.Trait.Branch.Make (Impl.Branch)
     module Commit = Vcs.Trait.Commit.Make (Impl.Commit)
     module Config = Vcs.Trait.Config.Make (Impl.Config)
+    module Current_branch = Vcs.Trait.Current_branch.Make (Impl.Current_branch)
+    module Current_revision = Vcs.Trait.Current_revision.Make (Impl.Current_revision)
     module File_system = Vcs.Trait.File_system.Make (Impl.File_system)
     module Git = Vcs.Trait.Git.Make (Impl.Git)
     module Init = Vcs.Trait.Init.Make (Impl.Init)
@@ -110,7 +116,6 @@ module Make (Runtime : Runtime.S) = struct
     module Name_status = Vcs.Trait.Name_status.Make (Impl.Name_status)
     module Num_status = Vcs.Trait.Num_status.Make (Impl.Num_status)
     module Refs = Vcs.Trait.Refs.Make (Impl.Refs)
-    module Rev_parse = Vcs.Trait.Rev_parse.Make (Impl.Rev_parse)
     module Show = Vcs.Trait.Show.Make (Impl.Show)
   end
 
@@ -120,6 +125,8 @@ module Make (Runtime : Runtime.S) = struct
       inherit Class.Branch.c t
       inherit Class.Commit.c t
       inherit Class.Config.c t
+      inherit Class.Current_branch.c t
+      inherit Class.Current_revision.c t
       inherit Class.File_system.c t
       inherit Class.Git.c t
       inherit Class.Init.c t
@@ -128,7 +135,6 @@ module Make (Runtime : Runtime.S) = struct
       inherit Class.Name_status.c t
       inherit Class.Num_status.c t
       inherit Class.Refs.c t
-      inherit Class.Rev_parse.c t
       inherit Class.Show.c t
     end
 

--- a/lib/volgo_git_backend/src/volgo_git_backend.mli
+++ b/lib/volgo_git_backend/src/volgo_git_backend.mli
@@ -54,6 +54,8 @@ module Trait : sig
     inherit Vcs.Trait.branch
     inherit Vcs.Trait.commit
     inherit Vcs.Trait.config
+    inherit Vcs.Trait.current_branch
+    inherit Vcs.Trait.current_revision
     inherit Vcs.Trait.file_system
     inherit Vcs.Trait.git
     inherit Vcs.Trait.init
@@ -62,7 +64,6 @@ module Trait : sig
     inherit Vcs.Trait.name_status
     inherit Vcs.Trait.num_status
     inherit Vcs.Trait.refs
-    inherit Vcs.Trait.rev_parse
     inherit Vcs.Trait.show
   end
 end
@@ -80,6 +81,8 @@ module type S = sig
   module Branch : Vcs.Trait.Branch.S with type t = t
   module Commit : Vcs.Trait.Commit.S with type t = t
   module Config : Vcs.Trait.Config.S with type t = t
+  module Current_branch : Vcs.Trait.Current_branch.S with type t = t
+  module Current_revision : Vcs.Trait.Current_revision.S with type t = t
   module File_system : Vcs.Trait.File_system.S with type t = t
   module Git : Vcs.Trait.Git.S with type t = t
   module Init : Vcs.Trait.Init.S with type t = t
@@ -88,7 +91,6 @@ module type S = sig
   module Name_status : Vcs.Trait.Name_status.S with type t = t
   module Num_status : Vcs.Trait.Num_status.S with type t = t
   module Refs : Vcs.Trait.Refs.S with type t = t
-  module Rev_parse : Vcs.Trait.Rev_parse.S with type t = t
   module Show : Vcs.Trait.Show.S with type t = t
 end
 
@@ -105,13 +107,14 @@ module Add = Add
 module Branch = Branch
 module Commit = Commit
 module Config = Config
+module Current_branch = Current_branch
+module Current_revision = Current_revision
 module Init = Init
 module Log = Log
 module Ls_files = Ls_files
 module Name_status = Name_status
 module Num_status = Num_status
 module Refs = Refs
-module Rev_parse = Rev_parse
 module Show = Show
 
 (** {1 Tests}

--- a/lib/volgo_hg_backend/src/current_revision.ml
+++ b/lib/volgo_hg_backend/src/current_revision.ml
@@ -24,26 +24,6 @@ open! Import
 module Make (Runtime : Runtime.S) = struct
   type t = Runtime.t
 
-  let current_branch (_ : t) ~repo_root:_ =
-    (* CR-soon mbarbin: Due to the current trait architecture we have to define
-       both methods as part of this trait implementation. But in fact, I'd like
-       to defer on this one, as it involves branches which requires more work.
-
-       I would like to re-consider this trait organization, and probably
-       consider splitting it according to what each method is focused on,
-       instead of grouping them due to the git command used in their current
-       implementation (rev-parse). Once this is done, we can rather *not*
-       implement [current_branch] instead of "implementing" with a dynamic
-       error. *)
-    Error
-      (Err.create
-         Pp.O.
-           [ Pp.text "Branches are not implemented in "
-             ++ Pp_tty.kwd (module String) "vcs-hg"
-             ++ Pp.text "."
-           ])
-  ;;
-
   let current_revision t ~repo_root =
     Runtime.hg
       t

--- a/lib/volgo_hg_backend/src/current_revision.mli
+++ b/lib/volgo_hg_backend/src/current_revision.mli
@@ -1,0 +1,26 @@
+(*_******************************************************************************)
+(*_  Volgo - a Versatile OCaml Library for Git Operations                       *)
+(*_  Copyright (C) 2024-2025 Mathieu Barbin <mathieu.barbin@gmail.com>          *)
+(*_                                                                             *)
+(*_  This file is part of Volgo.                                                *)
+(*_                                                                             *)
+(*_  Volgo is free software; you can redistribute it and/or modify it under     *)
+(*_  the terms of the GNU Lesser General Public License as published by the     *)
+(*_  Free Software Foundation either version 3 of the License, or any later     *)
+(*_  version, with the LGPL-3.0 Linking Exception.                              *)
+(*_                                                                             *)
+(*_  Volgo is distributed in the hope that it will be useful, but WITHOUT ANY   *)
+(*_  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS  *)
+(*_  FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License and    *)
+(*_  the file `NOTICE.md` at the root of this repository for more details.      *)
+(*_                                                                             *)
+(*_  You should have received a copy of the GNU Lesser General Public License   *)
+(*_  and the LGPL-3.0 Linking Exception along with this library. If not, see    *)
+(*_  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
+(*_******************************************************************************)
+
+module Make (Runtime : Runtime.S) : sig
+  type t = Runtime.t
+
+  include Vcs.Trait.Current_revision.S with type t := t
+end

--- a/lib/volgo_hg_backend/src/volgo_hg_backend.ml
+++ b/lib/volgo_hg_backend/src/volgo_hg_backend.ml
@@ -21,9 +21,9 @@
 
 module Add = Add
 module Commit = Commit
+module Current_revision = Current_revision
 module Init = Init
 module Ls_files = Ls_files
-module Rev_parse = Rev_parse
 module Runtime = Runtime
 module Private = struct end
 
@@ -31,11 +31,11 @@ module Trait = struct
   class type t = object
     inherit Vcs.Trait.add
     inherit Vcs.Trait.commit
+    inherit Vcs.Trait.current_revision
     inherit Vcs.Trait.file_system
     inherit Vcs.Trait.hg
     inherit Vcs.Trait.init
     inherit Vcs.Trait.ls_files
-    inherit Vcs.Trait.rev_parse
   end
 end
 
@@ -46,11 +46,11 @@ module type S = sig
 
   module Add : Vcs.Trait.Add.S with type t = t
   module Commit : Vcs.Trait.Commit.S with type t = t
+  module Current_revision : Vcs.Trait.Current_revision.S with type t = t
   module File_system : Vcs.Trait.File_system.S with type t = t
   module Hg : Vcs.Trait.Hg.S with type t = t
   module Init : Vcs.Trait.Init.S with type t = t
   module Ls_files : Vcs.Trait.Ls_files.S with type t = t
-  module Rev_parse : Vcs.Trait.Rev_parse.S with type t = t
 end
 
 module Make (Runtime : Runtime.S) = struct
@@ -59,32 +59,32 @@ module Make (Runtime : Runtime.S) = struct
   module Impl = struct
     module Add = Add.Make (Runtime)
     module Commit = Commit.Make (Runtime)
+    module Current_revision = Current_revision.Make (Runtime)
     module File_system = Runtime
     module Hg = Runtime
     module Init = Init.Make (Runtime)
     module Ls_files = Ls_files.Make (Runtime)
-    module Rev_parse = Rev_parse.Make (Runtime)
   end
 
   module Class = struct
     module Add = Vcs.Trait.Add.Make (Impl.Add)
     module Commit = Vcs.Trait.Commit.Make (Impl.Commit)
+    module Current_revision = Vcs.Trait.Current_revision.Make (Impl.Current_revision)
     module File_system = Vcs.Trait.File_system.Make (Impl.File_system)
     module Hg = Vcs.Trait.Hg.Make (Impl.Hg)
     module Init = Vcs.Trait.Init.Make (Impl.Init)
     module Ls_files = Vcs.Trait.Ls_files.Make (Impl.Ls_files)
-    module Rev_parse = Vcs.Trait.Rev_parse.Make (Impl.Rev_parse)
   end
 
   class c t =
     object
       inherit Class.Add.c t
       inherit Class.Commit.c t
+      inherit Class.Current_revision.c t
       inherit Class.File_system.c t
       inherit Class.Hg.c t
       inherit Class.Init.c t
       inherit Class.Ls_files.c t
-      inherit Class.Rev_parse.c t
     end
 
   include Impl

--- a/lib/volgo_hg_backend/src/volgo_hg_backend.mli
+++ b/lib/volgo_hg_backend/src/volgo_hg_backend.mli
@@ -52,11 +52,11 @@ module Trait : sig
   class type t = object
     inherit Vcs.Trait.add
     inherit Vcs.Trait.commit
+    inherit Vcs.Trait.current_revision
     inherit Vcs.Trait.file_system
     inherit Vcs.Trait.hg
     inherit Vcs.Trait.init
     inherit Vcs.Trait.ls_files
-    inherit Vcs.Trait.rev_parse
   end
 end
 
@@ -71,11 +71,11 @@ module type S = sig
 
   module Add : Vcs.Trait.Add.S with type t = t
   module Commit : Vcs.Trait.Commit.S with type t = t
+  module Current_revision : Vcs.Trait.Current_revision.S with type t = t
   module File_system : Vcs.Trait.File_system.S with type t = t
   module Hg : Vcs.Trait.Hg.S with type t = t
   module Init : Vcs.Trait.Init.S with type t = t
   module Ls_files : Vcs.Trait.Ls_files.S with type t = t
-  module Rev_parse : Vcs.Trait.Rev_parse.S with type t = t
 end
 
 module Make (Runtime : Runtime.S) : S with type t = Runtime.t
@@ -90,9 +90,9 @@ module Make (Runtime : Runtime.S) : S with type t = Runtime.t
 
 module Add = Add
 module Commit = Commit
+module Current_revision = Current_revision
 module Init = Init
 module Ls_files = Ls_files
-module Rev_parse = Rev_parse
 
 (** {1 Tests}
 

--- a/test/cram/run-hg.t
+++ b/test/cram/run-hg.t
@@ -26,7 +26,8 @@ Rev-parse.
   (Vcs.current_branch
    (repo_root
     $TESTCASE_ROOT))
-  Error: Branches are not implemented in [vcs-hg].
+  Error: Trait [Vcs.Trait.current_branch] method [current_branch] is not
+  available in this repository.
   [123]
 
 Adding a new file under a directory.

--- a/test/cram/run-hg.t
+++ b/test/cram/run-hg.t
@@ -13,13 +13,15 @@ includes specifics required by the GitHub Actions environment.
   $ volgo-vcs add hello
   $ rev0=$(volgo-vcs commit -m "Initial commit")
 
-Rev-parse.
+Current revision.
 
   $ hg log -r . --template "{node}\n" 2> /dev/null | sed -e "s/$rev0/rev0/g"
   rev0
 
   $ volgo-vcs current-revision | sed -e "s/$rev0/rev0/g"
   rev0
+
+Current branch.
 
   $ volgo-vcs current-branch
   Context:


### PR DESCRIPTION
Split trait rev_parse into 2.

This turns a dynamic error in the Mercurial back-end into a static one as it makes it clear that current_branch is not implemented.