### PR TITLE
Test Windows support further regarding conf-hg

### DIFF
--- a/volgo-tests.opam
+++ b/volgo-tests.opam
@@ -71,21 +71,8 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/mbarbin/vcs.git"
-# The goal is to fix most of the failure shown by [ocaml-ci] while working on
-# proper integration of [conf-hg] in the main repository.
+# We are now depending on [conf-hg] which handles most distributions.
+# We use this extra [depexts] config to test Windows support further.
 depexts: [
-  ["mercurial"] {os-family = "alpine"}
-  ["mercurial"] {os-family = "arch"}
-  ["mercurial"] {os-distribution = "centos"}
-  ["mercurial"] {os-family = "debian"}
-  ["mercurial"] {os-family = "fedora"}
-  ["mercurial"] {os = "freebsd"}
-  ["mercurial"] {os = "macos" & os-distribution = "homebrew"}
-  ["mercurial"] {os-distribution = "nixos"}
-  ["mercurial"] {os-distribution = "ol"}
-  ["mercurial"] {os = "openbsd"}
-  ["mercurial"] {os-family = "suse" | os-family = "opensuse"}
-  ["mercurial"] {os-family = "ubuntu"}
-  ["system:hg"] {os = "win32" & os-distribution = "cygwinports"}
-  ["mercurial"] {os = "cygwin"}
+  ["mercurial"] {os = "win32" & os-distribution = "cygwin"}
 ]

--- a/volgo-tests.opam
+++ b/volgo-tests.opam
@@ -71,8 +71,3 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/mbarbin/vcs.git"
-# We are now depending on [conf-hg] which handles most distributions.
-# We use this extra [depexts] config to test Windows support further.
-depexts: [
-  ["mercurial"] {os = "win32" & os-distribution = "cygwin"}
-]

--- a/volgo-tests.opam.template
+++ b/volgo-tests.opam.template
@@ -1,5 +1,0 @@
-# We are now depending on [conf-hg] which handles most distributions.
-# We use this extra [depexts] config to test Windows support further.
-depexts: [
-  ["mercurial"] {os = "win32" & os-distribution = "cygwin"}
-]

--- a/volgo-tests.opam.template
+++ b/volgo-tests.opam.template
@@ -1,18 +1,5 @@
-# The goal is to fix most of the failure shown by [ocaml-ci] while working on
-# proper integration of [conf-hg] in the main repository.
+# We are now depending on [conf-hg] which handles most distributions.
+# We use this extra [depexts] config to test Windows support further.
 depexts: [
-  ["mercurial"] {os-family = "alpine"}
-  ["mercurial"] {os-family = "arch"}
-  ["mercurial"] {os-distribution = "centos"}
-  ["mercurial"] {os-family = "debian"}
-  ["mercurial"] {os-family = "fedora"}
-  ["mercurial"] {os = "freebsd"}
-  ["mercurial"] {os = "macos" & os-distribution = "homebrew"}
-  ["mercurial"] {os-distribution = "nixos"}
-  ["mercurial"] {os-distribution = "ol"}
-  ["mercurial"] {os = "openbsd"}
-  ["mercurial"] {os-family = "suse" | os-family = "opensuse"}
-  ["mercurial"] {os-family = "ubuntu"}
-  ["system:hg"] {os = "win32" & os-distribution = "cygwinports"}
-  ["mercurial"] {os = "cygwin"}
+  ["mercurial"] {os = "win32" & os-distribution = "cygwin"}
 ]


### PR DESCRIPTION
Add an entry to test it with `ocam-ci`.

If this works with the Windows environment of the CI, we can propose this change upstream.