### PR TITLE
Remove sexp value

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -51,10 +51,10 @@
    (>= v0.16))
   (ppx_sexp_conv
    (>= v0.16))
-  (ppx_sexp_value
-   (>= v0.16))
   (ppxlib
-   (>= 0.33))))
+   (>= 0.33))
+  (sexplib0
+   (>= v0.16))))
 
 (package
  (name volgo-base)

--- a/example/hello_error.ml
+++ b/example/hello_error.ml
@@ -41,7 +41,7 @@ let%expect_test "hello error" =
   [%expect
     {|
     ((context
-       (Vcs.init ((path /invalid/path)))
+       (Vcs.init (path /invalid/path))
        ((prog git)
         (args (init .))
         (exit_status Unknown)
@@ -59,7 +59,7 @@ let%expect_test "hello error" =
   [%expect
     {|
     ((context
-       (Vcs.init ((path /invalid/path)))
+       (Vcs.init (path /invalid/path))
        ((prog git)
         (args (init .))
         (exit_status Unknown)
@@ -76,7 +76,7 @@ let%expect_test "hello error" =
   [%expect
     {|
     ((context
-       (Vcs.init ((path /invalid/path)))
+       (Vcs.init (path /invalid/path))
        ((prog git)
         (args (init .))
         (exit_status Unknown)
@@ -94,7 +94,7 @@ let%expect_test "hello error" =
     {|
     (Vcs (
       (context
-        (Vcs.init ((path /invalid/path)))
+        (Vcs.init (path /invalid/path))
         ((prog git)
          (args (init .))
          (exit_status Unknown)

--- a/example/hello_git_cli.ml
+++ b/example/hello_git_cli.ml
@@ -107,7 +107,7 @@ let%expect_test "hello cli" =
   [%expect
     {|
     ((context
-       (Vcs.git ((repo_root <REDACTED>) (args (rev-parse INVALID-REF))))
+       (Vcs.git (repo_root <REDACTED>) (args (rev-parse INVALID-REF)))
        ((prog git)
         (args        (rev-parse INVALID-REF))
         (exit_status (Exited    128))
@@ -137,7 +137,7 @@ let%expect_test "hello cli" =
   [%expect
     {|
     ((context
-       (Vcs.git ((repo_root <REDACTED>) (args (rev-parse INVALID-REF))))
+       (Vcs.git (repo_root <REDACTED>) (args (rev-parse INVALID-REF)))
        ((prog git)
         (args        (rev-parse INVALID-REF))
         (exit_status (Exited    128))
@@ -163,7 +163,7 @@ let%expect_test "hello cli" =
   [%expect
     {|
     ((context
-       (Vcs.git ((repo_root <REDACTED>) (args (rev-parse INVALID-REF))))
+       (Vcs.git (repo_root <REDACTED>) (args (rev-parse INVALID-REF)))
        ((prog git)
         (args        (rev-parse INVALID-REF))
         (exit_status (Exited    128))
@@ -193,7 +193,7 @@ let%expect_test "hello cli" =
   [%expect
     {|
     ((context
-       (Vcs.git ((repo_root <REDACTED>) (args (rev-parse INVALID-REF))))
+       (Vcs.git (repo_root <REDACTED>) (args (rev-parse INVALID-REF)))
        ((prog git)
         (args        (rev-parse INVALID-REF))
         (exit_status (Exited    128))
@@ -227,7 +227,7 @@ let%expect_test "hello cli" =
   [%expect
     {|
     ((context
-       (Vcs.git ((repo_root /bogus) (args (rev-parse --abbrev-ref HEAD))))
+       (Vcs.git (repo_root /bogus) (args (rev-parse --abbrev-ref HEAD)))
        ((prog git)
         (args (rev-parse --abbrev-ref HEAD))
         (exit_status Unknown)
@@ -263,7 +263,7 @@ let%expect_test "hello cli" =
     {|
     (Error (
       (context
-        (Vcs.git ((repo_root /bogus) (args (rev-parse --abbrev-ref HEAD))))
+        (Vcs.git (repo_root /bogus) (args (rev-parse --abbrev-ref HEAD)))
         ((prog git)
          (args (rev-parse --abbrev-ref HEAD))
          (exit_status Unknown)
@@ -285,7 +285,7 @@ let%expect_test "hello cli" =
   [%expect
     {|
     ((context
-       (Vcs.git ((repo_root <REDACTED>) (args (rev-parse --abbrev-ref bogus))))
+       (Vcs.git (repo_root <REDACTED>) (args (rev-parse --abbrev-ref bogus)))
        ((prog git)
         (args (rev-parse --abbrev-ref bogus))
         (exit_status (Exited 128))
@@ -321,7 +321,7 @@ let%expect_test "hello cli" =
     {|
     (Error (
       (context
-        (Vcs.git ((repo_root /bogus) (args (rev-parse --abbrev-ref HEAD))))
+        (Vcs.git (repo_root /bogus) (args (rev-parse --abbrev-ref HEAD)))
         ((prog git)
          (args (rev-parse --abbrev-ref HEAD))
          (exit_status Unknown)
@@ -362,7 +362,7 @@ let%expect_test "hello cli" =
   [%expect
     {|
     ((context
-       (Vcs.git ((repo_root <REDACTED>) (args (rev-parse --abbrev-ref HEAD))))
+       (Vcs.git (repo_root <REDACTED>) (args (rev-parse --abbrev-ref HEAD)))
        ((prog git)
         (args (rev-parse --abbrev-ref HEAD))
         (exit_status Unknown)
@@ -375,7 +375,7 @@ let%expect_test "hello cli" =
   [%expect
     {|
     ((context
-       (Vcs.git ((repo_root <REDACTED>) (args (rev-parse --abbrev-ref bogus))))
+       (Vcs.git (repo_root <REDACTED>) (args (rev-parse --abbrev-ref bogus)))
        ((prog git)
         (args (rev-parse --abbrev-ref bogus))
         (exit_status (Exited 128))

--- a/example/hello_vcs_git_unix.ml
+++ b/example/hello_vcs_git_unix.ml
@@ -73,7 +73,7 @@ let%expect_test "hello commit" =
   [%expect
     {|
     ((context
-       (Vcs.git ((repo_root /invalid/path) (args ())))
+       (Vcs.git (repo_root /invalid/path) (args ()))
        ((prog <REDACTED>)
         (args ())
         (exit_status Unknown)
@@ -100,7 +100,7 @@ let%expect_test "hello commit" =
   [%expect
     {|
     ((context
-       (Vcs.git ((repo_root <REDACTED>) (args (rev-parse INVALID-REF))))
+       (Vcs.git (repo_root <REDACTED>) (args (rev-parse INVALID-REF)))
        ((prog <REDACTED>)
         (args        (rev-parse INVALID-REF))
         (exit_status (Exited    128))

--- a/lib/vcs_test_helpers/test/test__vcs_test_helpers.ml
+++ b/lib/vcs_test_helpers/test/test__vcs_test_helpers.ml
@@ -76,7 +76,7 @@ let%expect_test "redact_sexp" =
   [%expect
     {|
     ((context
-       (Vcs.init ((path /invalid/path)))
+       (Vcs.init (path /invalid/path))
        ((prog git)
         (args (init .))
         (exit_status Unknown)
@@ -89,7 +89,7 @@ let%expect_test "redact_sexp" =
   [%expect
     {|
     ((context
-       (Vcs.init ((path /invalid/path)))
+       (Vcs.init (path /invalid/path))
        ((prog git)
         (args (init .))
         (exit_status Unknown)
@@ -103,7 +103,7 @@ let%expect_test "redact_sexp" =
   [%expect
     {|
     ((context
-       (Vcs.init ((path /invalid/path)))
+       (Vcs.init (path /invalid/path))
        ((prog git)
         (args (init .))
         (exit_status Unknown)

--- a/lib/volgo/src/dune
+++ b/lib/volgo/src/dune
@@ -13,7 +13,14 @@
   Sexplib0
   -open
   Sexplib0.Sexp_conv)
- (libraries astring fpath fpath-sexp0 pp pplumbing.err pplumbing.pp-tty)
+ (libraries
+  astring
+  fpath
+  fpath-sexp0
+  pp
+  pplumbing.err
+  pplumbing.pp-tty
+  sexplib0)
  (modules
   (:standard \ stdlib_compat4xx stdlib_compat5xx))
  (instrumentation

--- a/lib/volgo/src/dune
+++ b/lib/volgo/src/dune
@@ -34,11 +34,7 @@
   validated_string_intf
   vcs_intf)
  (preprocess
-  (pps
-   -unused-code-warnings=force
-   ppx_enumerate
-   ppx_sexp_conv
-   ppx_sexp_value)))
+  (pps -unused-code-warnings=force ppx_enumerate ppx_sexp_conv)))
 
 (rule
  (enabled_if

--- a/lib/volgo/src/import.mli
+++ b/lib/volgo/src/import.mli
@@ -24,6 +24,7 @@ open! Stdlib_compat
 module Array : sig
   include module type of ArrayLabels
 
+  val sexp_of_t : ('a -> Sexp.t) -> 'a t -> Sexp.t
   val create : len:int -> 'a -> 'a array
   val filter_mapi : 'a array -> f:(int -> 'a -> 'b option) -> 'b array
   val rev : 'a array -> 'a array
@@ -59,6 +60,7 @@ end
 module Int : sig
   include module type of Int
 
+  val sexp_of_t : t -> Sexp.t
   val incr : int ref -> unit
   val max_value : int
   val of_string : string -> int
@@ -69,6 +71,7 @@ end
 module List : sig
   include module type of ListLabels
 
+  val sexp_of_t : ('a -> Sexp.t) -> 'a t -> Sexp.t
   val dedup_and_sort : 'a list -> compare:('a -> 'a -> int) -> 'a list
   val filter_opt : 'a option list -> 'a list
   val find : 'a list -> f:('a -> bool) -> 'a option
@@ -80,6 +83,7 @@ end
 module Option : sig
   include module type of Option
 
+  val sexp_of_t : ('a -> Sexp.t) -> 'a t -> Sexp.t
   val map : 'a option -> f:('a -> 'b) -> 'b option
   val some_if : bool -> 'a -> 'a option
 end
@@ -117,6 +121,7 @@ end
 module String : sig
   include module type of StringLabels
 
+  val sexp_of_t : t -> Sexp.t
   val to_string : string -> string
   val chop_prefix : string -> prefix:string -> string option
   val chop_suffix : string -> suffix:string -> string option
@@ -138,3 +143,14 @@ val equal_int : int -> int -> bool
 val equal_string : string -> string -> bool
 val equal_list : ('a -> 'a -> bool) -> 'a list -> 'a list -> bool
 val hash_string : string -> int
+
+(** {1 Sexp helper} *)
+
+module type To_sexpable = sig
+  type t
+
+  val sexp_of_t : t -> Sexp.t
+end
+
+val sexp_field : (module To_sexpable with type t = 'a) -> string -> 'a -> Sexp.t
+val sexp_field' : ('a -> Sexp.t) -> string -> 'a -> Sexp.t

--- a/lib/volgo/src/process_output_handler.ml
+++ b/lib/volgo/src/process_output_handler.ml
@@ -44,7 +44,11 @@ module Result_impl = struct
       Error
         (Err.create
            [ Pp.text "Unexpected exit code."
-           ; Err.sexp [%sexp { accepted_codes : int list = List.map accept ~f:fst }]
+           ; Err.sexp
+               (sexp_field'
+                  (List.sexp_of_t Int.sexp_of_t)
+                  "accepted_codes"
+                  (List.map accept ~f:fst))
            ])
   ;;
 end

--- a/lib/volgo/test/test__git.ml
+++ b/lib/volgo/test/test__git.ml
@@ -63,7 +63,7 @@ let%expect_test "exit_code" =
   [%expect {| (Ok other) |}];
   (* Same remark as in [exit0] regarding the error trace. *)
   test { exit_code = 1; stdout = ""; stderr = "" };
-  [%expect {| (Raised ("Unexpected exit code." ((accepted_codes (0 42))))) |}];
+  [%expect {| (Raised ("Unexpected exit code." (accepted_codes (0 42)))) |}];
   ()
 ;;
 
@@ -106,6 +106,6 @@ let%expect_test "exit_code" =
   [%expect {| (Ok other) |}];
   (* Same remark as in [exit0] regarding the error trace. *)
   test { exit_code = 1; stdout = ""; stderr = "" };
-  [%expect {| (Error ("Unexpected exit code." ((accepted_codes (0 42))))) |}];
+  [%expect {| (Error ("Unexpected exit code." (accepted_codes (0 42)))) |}];
   ()
 ;;

--- a/lib/volgo/test/test__import.ml
+++ b/lib/volgo/test/test__import.ml
@@ -125,7 +125,7 @@ let%expect_test "Int_table.add_exn" =
   Int_table.add_exn table ~key:1_234 ~data:"one";
   require_does_raise [%here] (fun () ->
     Int_table.add_exn table ~key:1_234 ~data:"one prime");
-  [%expect {| ("Hashtbl.add_exn: key already present" ((key 1_234))) |}];
+  [%expect {| ("Hashtbl.add_exn: key already present" (key 1_234)) |}];
   ()
 ;;
 

--- a/lib/volgo/test/test__mock_revs.ml
+++ b/lib/volgo/test/test__mock_revs.ml
@@ -45,8 +45,8 @@ let%expect_test "mock revs" =
     Vcs.Mock_revs.add_exn t ~rev:rev0 ~mock_rev:mock_rev1);
   [%expect
     {|
-    ("Hashtbl.add_exn: key already present" ((
-      key dd5aabd331a75b90cd61725223964e47dd5aabd3)))
+    ("Hashtbl.add_exn: key already present" (
+      key dd5aabd331a75b90cd61725223964e47dd5aabd3))
     |}];
   (* Finally, as a convenience we can generate mock revision on the fly with
      [to_mock]. *)

--- a/lib/volgo/test/test__trait.ml
+++ b/lib/volgo/test/test__trait.ml
@@ -35,9 +35,9 @@ let%expect_test "unimplemented" =
   [%expect
     {|
     ((context (
-       Vcs.add (
-         (repo_root /path/to/repo)
-         (path      foo))))
+       Vcs.add
+       (repo_root /path/to/repo)
+       (path      foo)))
      (error
       "Trait [Vcs.Trait.add] method [add] is not available in this repository."))
     |}];
@@ -46,9 +46,9 @@ let%expect_test "unimplemented" =
   [%expect
     {|
     ((context (
-       Vcs.rename_current_branch (
-         (repo_root /path/to/repo)
-         (to_       foo))))
+       Vcs.rename_current_branch
+       (repo_root /path/to/repo)
+       (to_       foo)))
      (error
       "Trait [Vcs.Trait.branch] method [rename_current_branch] is not available in this repository."))
     |}];
@@ -56,7 +56,7 @@ let%expect_test "unimplemented" =
   test (fun () -> Vcs.commit vcs ~repo_root ~commit_message:(Vcs.Commit_message.v "_"));
   [%expect
     {|
-    ((context (Vcs.commit ((repo_root /path/to/repo))))
+    ((context (Vcs.commit (repo_root /path/to/repo)))
      (error
       "Trait [Vcs.Trait.commit] method [commit] is not available in this repository."))
     |}];
@@ -65,9 +65,9 @@ let%expect_test "unimplemented" =
   [%expect
     {|
     ((context (
-       Vcs.set_user_name (
-         (repo_root /path/to/repo)
-         (user_name user1))))
+       Vcs.set_user_name
+       (repo_root /path/to/repo)
+       (user_name user1)))
      (error
       "Trait [Vcs.Trait.config] method [set_user_name] is not available in this repository."))
     |}];
@@ -76,9 +76,9 @@ let%expect_test "unimplemented" =
   [%expect
     {|
     ((context (
-       Vcs.set_user_email (
-         (repo_root  /path/to/repo)
-         (user_email user1@mail.com))))
+       Vcs.set_user_email
+       (repo_root  /path/to/repo)
+       (user_email user1@mail.com)))
      (error
       "Trait [Vcs.Trait.config] method [set_user_email] is not available in this repository."))
     |}];
@@ -86,7 +86,7 @@ let%expect_test "unimplemented" =
   test (fun () -> Vcs.current_branch vcs ~repo_root);
   [%expect
     {|
-    ((context (Vcs.current_branch ((repo_root /path/to/repo))))
+    ((context (Vcs.current_branch (repo_root /path/to/repo)))
      (error
       "Trait [Vcs.Trait.current_branch] method [current_branch] is not available in this repository."))
     |}];
@@ -94,7 +94,7 @@ let%expect_test "unimplemented" =
   test (fun () -> Vcs.current_revision vcs ~repo_root);
   [%expect
     {|
-    ((context (Vcs.current_revision ((repo_root /path/to/repo))))
+    ((context (Vcs.current_revision (repo_root /path/to/repo)))
      (error
       "Trait [Vcs.Trait.current_revision] method [current_revision] is not available in this repository."))
     |}];
@@ -102,7 +102,7 @@ let%expect_test "unimplemented" =
   test (fun () -> Vcs.load_file vcs ~path:(Absolute_path.v "/path/to/file"));
   [%expect
     {|
-    ((context (Vcs.load_file ((path /path/to/file))))
+    ((context (Vcs.load_file (path /path/to/file)))
      (error
       "Trait [Vcs.Trait.file_system] method [load_file] is not available in this repository."))
     |}];
@@ -113,14 +113,14 @@ let%expect_test "unimplemented" =
       ~file_contents:(Vcs.File_contents.create "Hello"));
   [%expect
     {|
-    ((context (Vcs.save_file ((perms ()) (path /path/to/file))))
+    ((context (Vcs.save_file (perms ()) (path /path/to/file)))
      (error
       "Trait [Vcs.Trait.file_system] method [save_file] is not available in this repository."))
     |}];
   test (fun () -> Vcs.read_dir vcs ~dir:(Absolute_path.v "/path/to/dir"));
   [%expect
     {|
-    ((context (Vcs.read_dir ((dir /path/to/dir))))
+    ((context (Vcs.read_dir (dir /path/to/dir)))
      (error
       "Trait [Vcs.Trait.file_system] method [read_dir] is not available in this repository."))
     |}];
@@ -128,7 +128,7 @@ let%expect_test "unimplemented" =
   test (fun () -> Vcs.git vcs ~repo_root ~args:[ "status" ] ~f:Vcs.Git.exit0);
   [%expect
     {|
-    ((context (Vcs.git ((repo_root /path/to/repo) (args (status)))))
+    ((context (Vcs.git (repo_root /path/to/repo) (args (status))))
      (error
       "Trait [Vcs.Trait.git] method [git] is not available in this repository."))
     |}];
@@ -136,7 +136,7 @@ let%expect_test "unimplemented" =
   test (fun () -> Vcs.hg vcs ~repo_root ~args:[ "status" ] ~f:Vcs.Hg.exit0);
   [%expect
     {|
-    ((context (Vcs.hg ((repo_root /path/to/repo) (args (status)))))
+    ((context (Vcs.hg (repo_root /path/to/repo) (args (status))))
      (error
       "Trait [Vcs.Trait.hg] method [hg] is not available in this repository."))
     |}];
@@ -144,7 +144,7 @@ let%expect_test "unimplemented" =
   test (fun () -> Vcs.init vcs ~path:(Absolute_path.v "/path/to/dir"));
   [%expect
     {|
-    ((context (Vcs.init ((path /path/to/dir))))
+    ((context (Vcs.init (path /path/to/dir)))
      (error
       "Trait [Vcs.Trait.init] method [init] is not available in this repository."))
     |}];
@@ -152,7 +152,7 @@ let%expect_test "unimplemented" =
   test (fun () -> Vcs.log vcs ~repo_root);
   [%expect
     {|
-    ((context (Vcs.log ((repo_root /path/to/repo))))
+    ((context (Vcs.log (repo_root /path/to/repo)))
      (error
       "Trait [Vcs.Trait.log] method [get_log_lines] is not available in this repository."))
     |}];
@@ -161,9 +161,9 @@ let%expect_test "unimplemented" =
   [%expect
     {|
     ((context (
-       Vcs.ls_files (
-         (repo_root /path/to/repo)
-         (below     ./))))
+       Vcs.ls_files
+       (repo_root /path/to/repo)
+       (below     ./)))
      (error
       "Trait [Vcs.Trait.ls_files] method [ls_files] is not available in this repository."))
     |}];
@@ -173,12 +173,12 @@ let%expect_test "unimplemented" =
   [%expect
     {|
     ((context (
-       Vcs.name_status (
-         (repo_root /path/to/repo)
-         (changed (
-           Between
-           (src 3e8f3b8084fe4864ab5ecf955a8cf5093e8f3b80)
-           (dst 8f2865699c137a14c65ae28b83fde96b8f286569))))))
+       Vcs.name_status
+       (repo_root /path/to/repo)
+       (changed (
+         Between
+         (src 3e8f3b8084fe4864ab5ecf955a8cf5093e8f3b80)
+         (dst 8f2865699c137a14c65ae28b83fde96b8f286569)))))
      (error
       "Trait [Vcs.Trait.name_status] method [name_status] is not available in this repository."))
     |}];
@@ -188,12 +188,12 @@ let%expect_test "unimplemented" =
   [%expect
     {|
     ((context (
-       Vcs.num_status (
-         (repo_root /path/to/repo)
-         (changed (
-           Between
-           (src 3e8f3b8084fe4864ab5ecf955a8cf5093e8f3b80)
-           (dst 8f2865699c137a14c65ae28b83fde96b8f286569))))))
+       Vcs.num_status
+       (repo_root /path/to/repo)
+       (changed (
+         Between
+         (src 3e8f3b8084fe4864ab5ecf955a8cf5093e8f3b80)
+         (dst 8f2865699c137a14c65ae28b83fde96b8f286569)))))
      (error
       "Trait [Vcs.Trait.num_status] method [num_status] is not available in this repository."))
     |}];
@@ -201,7 +201,7 @@ let%expect_test "unimplemented" =
   test (fun () -> Vcs.refs vcs ~repo_root);
   [%expect
     {|
-    ((context (Vcs.refs ((repo_root /path/to/repo))))
+    ((context (Vcs.refs (repo_root /path/to/repo)))
      (error
       "Trait [Vcs.Trait.refs] method [get_refs_lines] is not available in this repository."))
     |}];
@@ -211,10 +211,10 @@ let%expect_test "unimplemented" =
   [%expect
     {|
     ((context (
-       Vcs.show_file_at_rev (
-         (repo_root /path/to/repo)
-         (rev       3e8f3b8084fe4864ab5ecf955a8cf5093e8f3b80)
-         (path      foo))))
+       Vcs.show_file_at_rev
+       (repo_root /path/to/repo)
+       (rev       3e8f3b8084fe4864ab5ecf955a8cf5093e8f3b80)
+       (path      foo)))
      (error
       "Trait [Vcs.Trait.show] method [show_file_at_rev] is not available in this repository."))
     |}];

--- a/lib/volgo_base/test/test__git.ml
+++ b/lib/volgo_base/test/test__git.ml
@@ -58,6 +58,6 @@ let%expect_test "exit_code" =
   [%expect {| (Ok other) |}];
   (* Same remark as in [exit0] regarding the error trace. *)
   test { exit_code = 1; stdout = ""; stderr = "" };
-  [%expect {| (Error ("Unexpected exit code." ((accepted_codes (0 42))))) |}];
+  [%expect {| (Error ("Unexpected exit code." (accepted_codes (0 42)))) |}];
   ()
 ;;

--- a/lib/volgo_git_backend/test/test__show.ml
+++ b/lib/volgo_git_backend/test/test__show.ml
@@ -31,6 +31,6 @@ let%expect_test "show" =
   test { exit_code = 128; stdout = "contents"; stderr = "" };
   [%expect {| (Ok Absent) |}];
   test { exit_code = 1; stdout = "contents"; stderr = "" };
-  [%expect {| (Error ("Unexpected exit code." ((accepted_codes (0 128))))) |}];
+  [%expect {| (Error ("Unexpected exit code." (accepted_codes (0 128)))) |}];
   ()
 ;;

--- a/lib/volgo_git_eio/test/test__file_system.ml
+++ b/lib/volgo_git_eio/test/test__file_system.ml
@@ -55,7 +55,7 @@ let%expect_test "read_dir" =
       print_s
         (Vcs_test_helpers.redact_sexp (Err.sexp_of_t err) ~fields:[ "dir"; "error" ])
   in
-  [%expect {| ((context (Vcs.read_dir ((dir <REDACTED>)))) (error <REDACTED>)) |}];
+  [%expect {| ((context (Vcs.read_dir (dir <REDACTED>))) (error <REDACTED>)) |}];
   let () =
     (* [Vcs.read_dir] errors out when called on an existing file rather than a
        directory. *)
@@ -70,6 +70,6 @@ let%expect_test "read_dir" =
       print_s
         (Vcs_test_helpers.redact_sexp (Err.sexp_of_t err) ~fields:[ "dir"; "error" ])
   in
-  [%expect {| ((context (Vcs.read_dir ((dir <REDACTED>)))) (error <REDACTED>)) |}];
+  [%expect {| ((context (Vcs.read_dir (dir <REDACTED>))) (error <REDACTED>)) |}];
   ()
 ;;

--- a/lib/volgo_git_unix/test/test__file_system.ml
+++ b/lib/volgo_git_unix/test/test__file_system.ml
@@ -51,7 +51,7 @@ let%expect_test "read_dir" =
   in
   [%expect
     {|
-    ((context (Vcs.read_dir ((dir <REDACTED>))))
+    ((context (Vcs.read_dir (dir <REDACTED>)))
      (error (Sys_error "/non-existing: No such file or directory")))
     |}];
   let () =
@@ -68,6 +68,6 @@ let%expect_test "read_dir" =
       print_s
         (Vcs_test_helpers.redact_sexp (Err.sexp_of_t err) ~fields:[ "dir"; "error" ])
   in
-  [%expect {| ((context (Vcs.read_dir ((dir <REDACTED>)))) (error <REDACTED>)) |}];
+  [%expect {| ((context (Vcs.read_dir (dir <REDACTED>))) (error <REDACTED>)) |}];
   ()
 ;;

--- a/lib/volgo_git_unix/test/test__hello_commit.ml
+++ b/lib/volgo_git_unix/test/test__hello_commit.ml
@@ -89,7 +89,7 @@ let%expect_test "read_dir" =
   in
   [%expect
     {|
-    ((context (Vcs.read_dir ((dir /invalid))))
+    ((context (Vcs.read_dir (dir /invalid)))
      (error (Sys_error "/invalid: No such file or directory")))
     |}];
   ()

--- a/lib/volgo_git_unix/test/test__path_resolution.ml
+++ b/lib/volgo_git_unix/test/test__path_resolution.ml
@@ -81,7 +81,7 @@ let%expect_test "hello path" =
   [%expect
     {|
     ((context
-       (Vcs.git ((repo_root <REDACTED>) (args (rev-parse INVALID-REF))))
+       (Vcs.git (repo_root <REDACTED>) (args (rev-parse INVALID-REF)))
        ((prog <REDACTED>)
         (args        (rev-parse INVALID-REF))
         (exit_status (Exited    128))
@@ -126,10 +126,10 @@ let%expect_test "hello path" =
   [%expect
     {|
     ((context
-       (Vcs.git (
+       (Vcs.git
          (repo_root <REDACTED>)
          (env       <REDACTED>)
-         (args (rev-parse INVALID-REF))))
+         (args (rev-parse INVALID-REF)))
        ((prog <REDACTED>)
         (args        (rev-parse INVALID-REF))
         (exit_status (Exited    128))
@@ -154,10 +154,10 @@ let%expect_test "hello path" =
   [%expect
     {|
     ((context
-       (Vcs.git (
+       (Vcs.git
          (repo_root <REDACTED>)
          (env       <REDACTED>)
-         (args (rev-parse INVALID-REF))))
+         (args (rev-parse INVALID-REF)))
        ((prog <REDACTED>)
         (args        (rev-parse INVALID-REF))
         (exit_status (Exited    42))
@@ -177,10 +177,10 @@ let%expect_test "hello path" =
   [%expect
     {|
     ((context
-       (Vcs.git (
+       (Vcs.git
          (repo_root <REDACTED>)
          (env       <REDACTED>)
-         (args (rev-parse INVALID-REF))))
+         (args (rev-parse INVALID-REF)))
        ((prog git)
         (args (rev-parse INVALID-REF))
         (exit_status Unknown)
@@ -197,10 +197,10 @@ let%expect_test "hello path" =
   [%expect
     {|
     ((context
-       (Vcs.git (
+       (Vcs.git
          (repo_root <REDACTED>)
          (env       <REDACTED>)
-         (args (rev-parse INVALID-REF))))
+         (args (rev-parse INVALID-REF)))
        ((prog <REDACTED>)
         (args        (rev-parse INVALID-REF))
         (exit_status (Exited    128))
@@ -217,7 +217,7 @@ let%expect_test "hello path" =
   [%expect
     {|
     ((context
-       (Vcs.git ((repo_root <REDACTED>) (args (rev-parse INVALID-REF))))
+       (Vcs.git (repo_root <REDACTED>) (args (rev-parse INVALID-REF)))
        ((prog <REDACTED>)
         (args        (rev-parse INVALID-REF))
         (exit_status (Exited    42))
@@ -235,7 +235,7 @@ let%expect_test "hello path" =
   [%expect
     {|
     ((context
-       (Vcs.git ((repo_root <REDACTED>) (args (rev-parse INVALID-REF))))
+       (Vcs.git (repo_root <REDACTED>) (args (rev-parse INVALID-REF)))
        ((prog git)
         (args (rev-parse INVALID-REF))
         (exit_status Unknown)

--- a/lib/volgo_hg_unix/test/test__hello_cli.ml
+++ b/lib/volgo_hg_unix/test/test__hello_cli.ml
@@ -93,7 +93,7 @@ let%expect_test "hello cli" =
   [%expect
     {|
     ((context
-       (Vcs.hg ((repo_root <REDACTED>) (args (bogus))))
+       (Vcs.hg (repo_root <REDACTED>) (args (bogus)))
        ((prog <REDACTED>)
         (args (bogus))
         (exit_status (Exited 255))
@@ -114,7 +114,7 @@ let%expect_test "hello cli" =
   [%expect
     {|
     ((context
-       (Vcs.hg ((repo_root <REDACTED>) (args (bogus))))
+       (Vcs.hg (repo_root <REDACTED>) (args (bogus)))
        ((prog <REDACTED>)
         (args (bogus))
         (exit_status (Exited 255))

--- a/test/expect/detached_head.ml
+++ b/test/expect/detached_head.ml
@@ -72,7 +72,7 @@ let%expect_test "detached-head" =
   in
   [%expect
     {|
-    ((context (Vcs.current_branch ((repo_root <REDACTED>))))
+    ((context (Vcs.current_branch (repo_root <REDACTED>)))
      (error "Not currently on any branch."))
     |}];
   let current_branch_opt = Vcs.Result.current_branch_opt vcs ~repo_root in

--- a/test/expect/small_graph.ml
+++ b/test/expect/small_graph.ml
@@ -68,9 +68,9 @@ let%expect_test "small graph" =
   [%expect
     {|
     ((context
-       (Vcs.add (
+       (Vcs.add
          (repo_root <REDACTED>)
-         (path      unknown-file.txt)))
+         (path      unknown-file.txt))
        ((prog git)
         (args        (add    unknown-file.txt))
         (exit_status (Exited 128))
@@ -96,7 +96,7 @@ let%expect_test "small graph" =
   [%expect
     {|
     ((context
-       (Vcs.commit ((repo_root <REDACTED>)))
+       (Vcs.commit (repo_root <REDACTED>))
        ((prog git)
         (args (commit -m "Nothing to commit"))
         (exit_status (Exited 1))
@@ -181,9 +181,9 @@ let%expect_test "small graph" =
   [%expect
     {|
     ((context
-       (Vcs.ls_files (
+       (Vcs.ls_files
          (repo_root <REDACTED>)
-         (below     dir)))
+         (below     dir))
        ((prog git)
         (args (ls-files --full-name))
         (exit_status Unknown)

--- a/volgo.opam
+++ b/volgo.opam
@@ -17,8 +17,8 @@ depends: [
   "pplumbing" {>= "0.0.14"}
   "ppx_enumerate" {>= "v0.16"}
   "ppx_sexp_conv" {>= "v0.16"}
-  "ppx_sexp_value" {>= "v0.16"}
   "ppxlib" {>= "0.33"}
+  "sexplib0" {>= "v0.16"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
- Reduce slightly dependencies from the kernal part of volgo, which is intended to have very little deps.
- This changes slightly some error sexps format (slightly improved with less parens) - not a consideration factor.