### PR TITLE
Deriving inline volgo

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -47,12 +47,6 @@
    (>= 2.0.0))
   (pplumbing
    (>= 0.0.14))
-  (ppx_enumerate
-   (>= v0.16))
-  (ppx_sexp_conv
-   (>= v0.16))
-  (ppxlib
-   (>= 0.33))
   (sexplib0
    (>= v0.16))))
 

--- a/example/hello_git_cli.ml
+++ b/example/hello_git_cli.ml
@@ -92,10 +92,15 @@ let%expect_test "hello cli" =
   (* Cases where the command fails. *)
   let () =
     match
-      Vcs.git vcs ~repo_root ~args:[ "rev-parse"; "INVALID-REF" ] ~f:(fun output ->
-        if output.exit_code = 0
-        then assert false [@coverage off]
-        else failwith "Hello invalid exit code")
+      Vcs.git
+        vcs
+        ~run_in_subdir:Vcs.Path_in_repo.root
+        ~repo_root
+        ~args:[ "rev-parse"; "INVALID-REF" ]
+        ~f:(fun output ->
+          if output.exit_code = 0
+          then assert false [@coverage off]
+          else failwith "Hello invalid exit code")
     with
     | _ -> assert false [@coverage off]
     | exception Err.E err ->
@@ -107,7 +112,10 @@ let%expect_test "hello cli" =
   [%expect
     {|
     ((context
-       (Vcs.git (repo_root <REDACTED>) (args (rev-parse INVALID-REF)))
+       (Vcs.git
+         (repo_root     <REDACTED>)
+         (run_in_subdir ./)
+         (args (rev-parse INVALID-REF)))
        ((prog git)
         (args        (rev-parse INVALID-REF))
         (exit_status (Exited    128))

--- a/lib/volgo/src/bit_vector.mli
+++ b/lib/volgo/src/bit_vector.mli
@@ -24,7 +24,11 @@
     At some point, with some benchmarks for sanity checks, it seems desirable to
     switch to a less naive implementation. *)
 
-type t [@@deriving sexp_of]
+type t [@@deriving_inline sexp_of]
+
+val sexp_of_t : t -> Sexplib0.Sexp.t
+
+[@@@deriving.end]
 
 val create : len:int -> bool -> t
 val length : t -> int

--- a/lib/volgo/src/bit_vector.mli
+++ b/lib/volgo/src/bit_vector.mli
@@ -24,12 +24,9 @@
     At some point, with some benchmarks for sanity checks, it seems desirable to
     switch to a less naive implementation. *)
 
-type t [@@deriving_inline sexp_of]
+type t
 
-val sexp_of_t : t -> Sexplib0.Sexp.t
-
-[@@@deriving.end]
-
+val sexp_of_t : t -> Sexp.t
 val create : len:int -> bool -> t
 val length : t -> int
 val set : t -> int -> bool -> unit

--- a/lib/volgo/src/dune
+++ b/lib/volgo/src/dune
@@ -26,15 +26,22 @@
  (instrumentation
   (backend bisect_ppx))
  (lint
-  (pps ppx_js_style -allow-let-operators -check-doc-comments))
+  (pps
+   -unused-code-warnings=force
+   ;; Actual linters
+   ppx_js_style
+   -allow-let-operators
+   -check-doc-comments
+   ;; Ppx used with deriving_inline
+   ppx_enumerate
+   ppx_sexp_conv))
  (modules_without_implementation
   error_intf
   process_intf
   process_output_handler_intf
   validated_string_intf
   vcs_intf)
- (preprocess
-  (pps -unused-code-warnings=force ppx_enumerate ppx_sexp_conv)))
+ (preprocess no_preprocessing))
 
 (rule
  (enabled_if

--- a/lib/volgo/src/error_intf.mli
+++ b/lib/volgo/src/error_intf.mli
@@ -29,11 +29,9 @@ module type S = sig
       [Vcs.Non_raising.Make]. *)
 
   (** [t] must represent the type of errors in your monad. *)
-  type t [@@deriving_inline sexp_of]
+  type t
 
-  val sexp_of_t : t -> Sexplib0.Sexp.t
-
-  [@@@deriving.end]
+  val sexp_of_t : t -> Sexp.t
 
   (** The conversion functions you need to provide. *)
 

--- a/lib/volgo/src/error_intf.mli
+++ b/lib/volgo/src/error_intf.mli
@@ -29,7 +29,11 @@ module type S = sig
       [Vcs.Non_raising.Make]. *)
 
   (** [t] must represent the type of errors in your monad. *)
-  type t [@@deriving sexp_of]
+  type t [@@deriving_inline sexp_of]
+
+  val sexp_of_t : t -> Sexplib0.Sexp.t
+
+  [@@@deriving.end]
 
   (** The conversion functions you need to provide. *)
 

--- a/lib/volgo/src/graph.ml
+++ b/lib/volgo/src/graph.ml
@@ -46,7 +46,53 @@ module Node_kind = struct
           ; parent1 : Node.t
           ; parent2 : Node.t
           }
-    [@@deriving sexp_of]
+    [@@deriving_inline sexp_of]
+
+    let sexp_of_t =
+      (function
+       | Root { rev = rev__002_ } ->
+         let bnds__001_ = ([] : _ Stdlib.List.t) in
+         let bnds__001_ =
+           let arg__003_ = Rev.sexp_of_t rev__002_ in
+           (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "rev"; arg__003_ ] :: bnds__001_
+            : _ Stdlib.List.t)
+         in
+         Sexplib0.Sexp.List (Sexplib0.Sexp.Atom "Root" :: bnds__001_)
+       | Commit { rev = rev__005_; parent = parent__007_ } ->
+         let bnds__004_ = ([] : _ Stdlib.List.t) in
+         let bnds__004_ =
+           let arg__008_ = Node.sexp_of_t parent__007_ in
+           (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "parent"; arg__008_ ] :: bnds__004_
+            : _ Stdlib.List.t)
+         in
+         let bnds__004_ =
+           let arg__006_ = Rev.sexp_of_t rev__005_ in
+           (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "rev"; arg__006_ ] :: bnds__004_
+            : _ Stdlib.List.t)
+         in
+         Sexplib0.Sexp.List (Sexplib0.Sexp.Atom "Commit" :: bnds__004_)
+       | Merge { rev = rev__010_; parent1 = parent1__012_; parent2 = parent2__014_ } ->
+         let bnds__009_ = ([] : _ Stdlib.List.t) in
+         let bnds__009_ =
+           let arg__015_ = Node.sexp_of_t parent2__014_ in
+           (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "parent2"; arg__015_ ] :: bnds__009_
+            : _ Stdlib.List.t)
+         in
+         let bnds__009_ =
+           let arg__013_ = Node.sexp_of_t parent1__012_ in
+           (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "parent1"; arg__013_ ] :: bnds__009_
+            : _ Stdlib.List.t)
+         in
+         let bnds__009_ =
+           let arg__011_ = Rev.sexp_of_t rev__010_ in
+           (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "rev"; arg__011_ ] :: bnds__009_
+            : _ Stdlib.List.t)
+         in
+         Sexplib0.Sexp.List (Sexplib0.Sexp.Atom "Merge" :: bnds__009_)
+       : t -> Sexplib0.Sexp.t)
+    ;;
+
+    [@@@deriving.end]
 
     let equal =
       (fun a__001_ b__002_ ->
@@ -395,7 +441,20 @@ module Descendance = struct
     | Strict_ancestor
     | Strict_descendant
     | Other
-  [@@deriving enumerate, sexp_of]
+  [@@deriving_inline enumerate, sexp_of]
+
+  let all = ([ Same_node; Strict_ancestor; Strict_descendant; Other ] : t list)
+
+  let sexp_of_t =
+    (function
+     | Same_node -> Sexplib0.Sexp.Atom "Same_node"
+     | Strict_ancestor -> Sexplib0.Sexp.Atom "Strict_ancestor"
+     | Strict_descendant -> Sexplib0.Sexp.Atom "Strict_descendant"
+     | Other -> Sexplib0.Sexp.Atom "Other"
+     : t -> Sexplib0.Sexp.t)
+  ;;
+
+  [@@@deriving.end]
 
   let compare = (compare : t -> t -> int)
   let equal = (( = ) : t -> t -> bool)
@@ -440,7 +499,26 @@ module Subgraph = struct
       { log : Log.t
       ; refs : Refs.t
       }
-    [@@deriving sexp_of]
+    [@@deriving_inline sexp_of]
+
+    let sexp_of_t =
+      (fun { log = log__017_; refs = refs__019_ } ->
+         let bnds__016_ = ([] : _ Stdlib.List.t) in
+         let bnds__016_ =
+           let arg__020_ = Refs.sexp_of_t refs__019_ in
+           (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "refs"; arg__020_ ] :: bnds__016_
+            : _ Stdlib.List.t)
+         in
+         let bnds__016_ =
+           let arg__018_ = Log.sexp_of_t log__017_ in
+           (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "log"; arg__018_ ] :: bnds__016_
+            : _ Stdlib.List.t)
+         in
+         Sexplib0.Sexp.List bnds__016_
+       : t -> Sexplib0.Sexp.t)
+    ;;
+
+    [@@@deriving.end]
   end
 
   include T
@@ -513,7 +591,60 @@ module Summary = struct
     ; leaves : (Rev.t * string list) list
     ; subgraphs : t list [@sexp_drop_if List.is_empty]
     }
-  [@@deriving sexp_of]
+  [@@deriving_inline sexp_of]
+
+  let rec sexp_of_t =
+    (let (drop_if__037_ : t list -> Stdlib.Bool.t) = List.is_empty in
+     fun { refs = refs__022_
+         ; roots = roots__028_
+         ; leaves = leaves__030_
+         ; subgraphs = subgraphs__038_
+         } ->
+       let bnds__021_ = ([] : _ Stdlib.List.t) in
+       let bnds__021_ =
+         if drop_if__037_ subgraphs__038_
+         then bnds__021_
+         else (
+           let arg__040_ = (sexp_of_list sexp_of_t) subgraphs__038_ in
+           let bnd__039_ =
+             Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "subgraphs"; arg__040_ ]
+           in
+           (bnd__039_ :: bnds__021_ : _ Stdlib.List.t))
+       in
+       let bnds__021_ =
+         let arg__031_ =
+           sexp_of_list
+             (fun (arg0__032_, arg1__033_) ->
+                let res0__034_ = Rev.sexp_of_t arg0__032_
+                and res1__035_ = sexp_of_list sexp_of_string arg1__033_ in
+                Sexplib0.Sexp.List [ res0__034_; res1__035_ ])
+             leaves__030_
+         in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "leaves"; arg__031_ ] :: bnds__021_
+          : _ Stdlib.List.t)
+       in
+       let bnds__021_ =
+         let arg__029_ = sexp_of_list Rev.sexp_of_t roots__028_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "roots"; arg__029_ ] :: bnds__021_
+          : _ Stdlib.List.t)
+       in
+       let bnds__021_ =
+         let arg__023_ =
+           sexp_of_list
+             (fun (arg0__024_, arg1__025_) ->
+                let res0__026_ = Rev.sexp_of_t arg0__024_
+                and res1__027_ = sexp_of_string arg1__025_ in
+                Sexplib0.Sexp.List [ res0__026_; res1__027_ ])
+             refs__022_
+         in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "refs"; arg__023_ ] :: bnds__021_
+          : _ Stdlib.List.t)
+       in
+       Sexplib0.Sexp.List bnds__021_
+     : t -> Sexplib0.Sexp.t)
+  ;;
+
+  [@@@deriving.end]
 end
 
 let rec summary t =

--- a/lib/volgo/src/graph.mli
+++ b/lib/volgo/src/graph.mli
@@ -29,7 +29,11 @@
     of what needs to be sent to a process holding such a value in memory to
     complete its view of a graph. *)
 
-type t [@@deriving sexp_of]
+type t [@@deriving_inline sexp_of]
+
+val sexp_of_t : t -> Sexplib0.Sexp.t
+
+[@@@deriving.end]
 
 (** Create an empty graph that has no nodes. *)
 val create : unit -> t
@@ -94,7 +98,11 @@ module Node_kind : sig
         ; parent1 : Node.t
         ; parent2 : Node.t
         }
-  [@@deriving sexp_of]
+  [@@deriving_inline sexp_of]
+
+  val sexp_of_t : t -> Sexplib0.Sexp.t
+
+  [@@@deriving.end]
 
   val equal : t -> t -> bool
 
@@ -253,7 +261,11 @@ module Subgraph : sig
     { log : Log.t
     ; refs : Refs.t
     }
-  [@@deriving sexp_of]
+  [@@deriving_inline sexp_of]
+
+  val sexp_of_t : t -> Sexplib0.Sexp.t
+
+  [@@@deriving.end]
 
   val is_empty : t -> bool
 end
@@ -270,7 +282,11 @@ val of_subgraph : Subgraph.t -> t
 (** {1 Summary} *)
 
 module Summary : sig
-  type t [@@deriving sexp_of]
+  type t [@@deriving_inline sexp_of]
+
+  val sexp_of_t : t -> Sexplib0.Sexp.t
+
+  [@@@deriving.end]
 end
 
 (** Print a summary for use in expect test and quick exploratory tests *)

--- a/lib/volgo/src/graph.mli
+++ b/lib/volgo/src/graph.mli
@@ -29,11 +29,9 @@
     of what needs to be sent to a process holding such a value in memory to
     complete its view of a graph. *)
 
-type t [@@deriving_inline sexp_of]
+type t
 
-val sexp_of_t : t -> Sexplib0.Sexp.t
-
-[@@@deriving.end]
+val sexp_of_t : t -> Sexp.t
 
 (** Create an empty graph that has no nodes. *)
 val create : unit -> t
@@ -98,12 +96,8 @@ module Node_kind : sig
         ; parent1 : Node.t
         ; parent2 : Node.t
         }
-  [@@deriving_inline sexp_of]
 
-  val sexp_of_t : t -> Sexplib0.Sexp.t
-
-  [@@@deriving.end]
-
+  val sexp_of_t : t -> Sexp.t
   val equal : t -> t -> bool
 
   (** A helper to access the revision of the node itself. This simply returns
@@ -261,12 +255,8 @@ module Subgraph : sig
     { log : Log.t
     ; refs : Refs.t
     }
-  [@@deriving_inline sexp_of]
 
-  val sexp_of_t : t -> Sexplib0.Sexp.t
-
-  [@@@deriving.end]
-
+  val sexp_of_t : t -> Sexp.t
   val is_empty : t -> bool
 end
 
@@ -282,11 +272,9 @@ val of_subgraph : Subgraph.t -> t
 (** {1 Summary} *)
 
 module Summary : sig
-  type t [@@deriving_inline sexp_of]
+  type t
 
   val sexp_of_t : t -> Sexplib0.Sexp.t
-
-  [@@@deriving.end]
 end
 
 (** Print a summary for use in expect test and quick exploratory tests *)

--- a/lib/volgo/src/import.ml
+++ b/lib/volgo/src/import.ml
@@ -228,7 +228,32 @@ module Result = struct
   type ('a, 'b) t = ('a, 'b) Result.t =
     | Ok of 'a
     | Error of 'b
-  [@@deriving sexp_of]
+  [@@deriving_inline sexp_of]
+
+  let sexp_of_t
+    :  'a 'b.
+       ('a -> Sexplib0.Sexp.t)
+    -> ('b -> Sexplib0.Sexp.t)
+    -> ('a, 'b) t
+    -> Sexplib0.Sexp.t
+    =
+    fun (type a__007_) ->
+    fun (type b__008_) ->
+    (fun _of_a__001_ ->
+       fun _of_b__002_ -> function
+         | Ok arg0__003_ ->
+           let res0__004_ = _of_a__001_ arg0__003_ in
+           Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "Ok"; res0__004_ ]
+         | Error arg0__005_ ->
+           let res0__006_ = _of_b__002_ arg0__005_ in
+           Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "Error"; res0__006_ ]
+     : (a__007_ -> Sexplib0.Sexp.t)
+       -> (b__008_ -> Sexplib0.Sexp.t)
+       -> (a__007_, b__008_) t
+       -> Sexplib0.Sexp.t)
+  ;;
+
+  [@@@deriving.end]
 
   include (Result : module type of Result with type ('a, 'b) t := ('a, 'b) t)
 

--- a/lib/volgo/src/import.ml
+++ b/lib/volgo/src/import.ml
@@ -228,8 +228,8 @@ module Result = struct
   type ('a, 'b) t = ('a, 'b) Result.t =
     | Ok of 'a
     | Error of 'b
-  [@@deriving_inline sexp_of]
 
+  (* Not checked with deriving_inline due some formatting unstability. *)
   let sexp_of_t
     :  'a 'b.
        ('a -> Sexplib0.Sexp.t)
@@ -252,8 +252,6 @@ module Result = struct
        -> (a__007_, b__008_) t
        -> Sexplib0.Sexp.t)
   ;;
-
-  [@@@deriving.end]
 
   include (Result : module type of Result with type ('a, 'b) t := ('a, 'b) t)
 

--- a/lib/volgo/src/log.ml
+++ b/lib/volgo/src/log.ml
@@ -35,7 +35,53 @@ module Line = struct
         ; parent1 : Rev.t
         ; parent2 : Rev.t
         }
-  [@@deriving sexp_of]
+  [@@deriving_inline sexp_of]
+
+  let sexp_of_t =
+    (function
+     | Root { rev = rev__002_ } ->
+       let bnds__001_ = ([] : _ Stdlib.List.t) in
+       let bnds__001_ =
+         let arg__003_ = Rev.sexp_of_t rev__002_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "rev"; arg__003_ ] :: bnds__001_
+          : _ Stdlib.List.t)
+       in
+       Sexplib0.Sexp.List (Sexplib0.Sexp.Atom "Root" :: bnds__001_)
+     | Commit { rev = rev__005_; parent = parent__007_ } ->
+       let bnds__004_ = ([] : _ Stdlib.List.t) in
+       let bnds__004_ =
+         let arg__008_ = Rev.sexp_of_t parent__007_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "parent"; arg__008_ ] :: bnds__004_
+          : _ Stdlib.List.t)
+       in
+       let bnds__004_ =
+         let arg__006_ = Rev.sexp_of_t rev__005_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "rev"; arg__006_ ] :: bnds__004_
+          : _ Stdlib.List.t)
+       in
+       Sexplib0.Sexp.List (Sexplib0.Sexp.Atom "Commit" :: bnds__004_)
+     | Merge { rev = rev__010_; parent1 = parent1__012_; parent2 = parent2__014_ } ->
+       let bnds__009_ = ([] : _ Stdlib.List.t) in
+       let bnds__009_ =
+         let arg__015_ = Rev.sexp_of_t parent2__014_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "parent2"; arg__015_ ] :: bnds__009_
+          : _ Stdlib.List.t)
+       in
+       let bnds__009_ =
+         let arg__013_ = Rev.sexp_of_t parent1__012_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "parent1"; arg__013_ ] :: bnds__009_
+          : _ Stdlib.List.t)
+       in
+       let bnds__009_ =
+         let arg__011_ = Rev.sexp_of_t rev__010_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "rev"; arg__011_ ] :: bnds__009_
+          : _ Stdlib.List.t)
+       in
+       Sexplib0.Sexp.List (Sexplib0.Sexp.Atom "Merge" :: bnds__009_)
+     : t -> Sexplib0.Sexp.t)
+  ;;
+
+  [@@@deriving.end]
 
   let equal =
     (fun a__001_ b__002_ ->
@@ -66,7 +112,13 @@ end
 module T = struct
   [@@@coverage off]
 
-  type t = Line.t list [@@deriving sexp_of]
+  type t = Line.t list [@@deriving_inline sexp_of]
+
+  let sexp_of_t =
+    (fun x__016_ -> sexp_of_list Line.sexp_of_t x__016_ : t -> Sexplib0.Sexp.t)
+  ;;
+
+  [@@@deriving.end]
 
   let equal a b = equal_list Line.equal a b
 end

--- a/lib/volgo/src/log.mli
+++ b/lib/volgo/src/log.mli
@@ -36,22 +36,15 @@ module Line : sig
         ; parent1 : Rev.t
         ; parent2 : Rev.t
         }
-  [@@deriving_inline sexp_of]
 
-  val sexp_of_t : t -> Sexplib0.Sexp.t
-
-  [@@@deriving.end]
-
+  val sexp_of_t : t -> Sexp.t
   val equal : t -> t -> bool
   val rev : t -> Rev.t
 end
 
-type t = Line.t list [@@deriving_inline sexp_of]
+type t = Line.t list
 
-val sexp_of_t : t -> Sexplib0.Sexp.t
-
-[@@@deriving.end]
-
+val sexp_of_t : t -> Sexp.t
 val equal : t -> t -> bool
 
 (** {1 Accessors} *)

--- a/lib/volgo/src/log.mli
+++ b/lib/volgo/src/log.mli
@@ -36,13 +36,21 @@ module Line : sig
         ; parent1 : Rev.t
         ; parent2 : Rev.t
         }
-  [@@deriving sexp_of]
+  [@@deriving_inline sexp_of]
+
+  val sexp_of_t : t -> Sexplib0.Sexp.t
+
+  [@@@deriving.end]
 
   val equal : t -> t -> bool
   val rev : t -> Rev.t
 end
 
-type t = Line.t list [@@deriving sexp_of]
+type t = Line.t list [@@deriving_inline sexp_of]
+
+val sexp_of_t : t -> Sexplib0.Sexp.t
+
+[@@@deriving.end]
 
 val equal : t -> t -> bool
 

--- a/lib/volgo/src/mock_rev_gen.ml
+++ b/lib/volgo/src/mock_rev_gen.ml
@@ -28,7 +28,26 @@ module T = struct
     { name : string
     ; mutable counter : int
     }
-  [@@deriving sexp_of]
+  [@@deriving_inline sexp_of]
+
+  let sexp_of_t =
+    (fun { name = name__002_; counter = counter__004_ } ->
+       let bnds__001_ = ([] : _ Stdlib.List.t) in
+       let bnds__001_ =
+         let arg__005_ = sexp_of_int counter__004_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "counter"; arg__005_ ] :: bnds__001_
+          : _ Stdlib.List.t)
+       in
+       let bnds__001_ =
+         let arg__003_ = sexp_of_string name__002_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "name"; arg__003_ ] :: bnds__001_
+          : _ Stdlib.List.t)
+       in
+       Sexplib0.Sexp.List bnds__001_
+     : t -> Sexplib0.Sexp.t)
+  ;;
+
+  [@@@deriving.end]
 end
 
 include T

--- a/lib/volgo/src/mock_rev_gen.mli
+++ b/lib/volgo/src/mock_rev_gen.mli
@@ -21,12 +21,9 @@
 
 (** Creating mock revisions for use in expect tests. *)
 
-type t [@@deriving_inline sexp_of]
+type t
 
-val sexp_of_t : t -> Sexplib0.Sexp.t
-
-[@@@deriving.end]
-
+val sexp_of_t : t -> Sexp.t
 val create : name:string -> t
 
 (** This is the main function provided by the module. Given a state, return a

--- a/lib/volgo/src/mock_rev_gen.mli
+++ b/lib/volgo/src/mock_rev_gen.mli
@@ -21,7 +21,11 @@
 
 (** Creating mock revisions for use in expect tests. *)
 
-type t [@@deriving sexp_of]
+type t [@@deriving_inline sexp_of]
+
+val sexp_of_t : t -> Sexplib0.Sexp.t
+
+[@@@deriving.end]
 
 val create : name:string -> t
 

--- a/lib/volgo/src/name_status.ml
+++ b/lib/volgo/src/name_status.ml
@@ -62,7 +62,59 @@ module Change = struct
         ; dst : Path_in_repo.t
         ; similarity : int
         }
-  [@@deriving sexp_of]
+  [@@deriving_inline sexp_of]
+
+  let sexp_of_t =
+    (function
+     | Added arg0__001_ ->
+       let res0__002_ = Path_in_repo.sexp_of_t arg0__001_ in
+       Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "Added"; res0__002_ ]
+     | Removed arg0__003_ ->
+       let res0__004_ = Path_in_repo.sexp_of_t arg0__003_ in
+       Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "Removed"; res0__004_ ]
+     | Modified arg0__005_ ->
+       let res0__006_ = Path_in_repo.sexp_of_t arg0__005_ in
+       Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "Modified"; res0__006_ ]
+     | Copied { src = src__008_; dst = dst__010_; similarity = similarity__012_ } ->
+       let bnds__007_ = ([] : _ Stdlib.List.t) in
+       let bnds__007_ =
+         let arg__013_ = sexp_of_int similarity__012_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "similarity"; arg__013_ ] :: bnds__007_
+          : _ Stdlib.List.t)
+       in
+       let bnds__007_ =
+         let arg__011_ = Path_in_repo.sexp_of_t dst__010_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "dst"; arg__011_ ] :: bnds__007_
+          : _ Stdlib.List.t)
+       in
+       let bnds__007_ =
+         let arg__009_ = Path_in_repo.sexp_of_t src__008_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "src"; arg__009_ ] :: bnds__007_
+          : _ Stdlib.List.t)
+       in
+       Sexplib0.Sexp.List (Sexplib0.Sexp.Atom "Copied" :: bnds__007_)
+     | Renamed { src = src__015_; dst = dst__017_; similarity = similarity__019_ } ->
+       let bnds__014_ = ([] : _ Stdlib.List.t) in
+       let bnds__014_ =
+         let arg__020_ = sexp_of_int similarity__019_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "similarity"; arg__020_ ] :: bnds__014_
+          : _ Stdlib.List.t)
+       in
+       let bnds__014_ =
+         let arg__018_ = Path_in_repo.sexp_of_t dst__017_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "dst"; arg__018_ ] :: bnds__014_
+          : _ Stdlib.List.t)
+       in
+       let bnds__014_ =
+         let arg__016_ = Path_in_repo.sexp_of_t src__015_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "src"; arg__016_ ] :: bnds__014_
+          : _ Stdlib.List.t)
+       in
+       Sexplib0.Sexp.List (Sexplib0.Sexp.Atom "Renamed" :: bnds__014_)
+     : t -> Sexplib0.Sexp.t)
+  ;;
+
+  [@@@deriving.end]
 
   let equal =
     (fun a__001_ b__002_ ->
@@ -94,7 +146,13 @@ module Change = struct
 end
 
 module T = struct
-  type t = Change.t list [@@deriving sexp_of]
+  type t = Change.t list [@@deriving_inline sexp_of]
+
+  let sexp_of_t =
+    (fun x__021_ -> sexp_of_list Change.sexp_of_t x__021_ : t -> Sexplib0.Sexp.t)
+  ;;
+
+  [@@@deriving.end]
 end
 
 include T
@@ -138,7 +196,26 @@ module Changed = struct
         { src : Rev.t
         ; dst : Rev.t
         }
-  [@@deriving sexp_of]
+  [@@deriving_inline sexp_of]
+
+  let sexp_of_t =
+    (fun (Between { src = src__023_; dst = dst__025_ }) ->
+       let bnds__022_ = ([] : _ Stdlib.List.t) in
+       let bnds__022_ =
+         let arg__026_ = Rev.sexp_of_t dst__025_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "dst"; arg__026_ ] :: bnds__022_
+          : _ Stdlib.List.t)
+       in
+       let bnds__022_ =
+         let arg__024_ = Rev.sexp_of_t src__023_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "src"; arg__024_ ] :: bnds__022_
+          : _ Stdlib.List.t)
+       in
+       Sexplib0.Sexp.List (Sexplib0.Sexp.Atom "Between" :: bnds__022_)
+     : t -> Sexplib0.Sexp.t)
+  ;;
+
+  [@@@deriving.end]
 
   let equal =
     (fun a__034_ b__035_ ->

--- a/lib/volgo/src/name_status.mli
+++ b/lib/volgo/src/name_status.mli
@@ -57,12 +57,20 @@ module Change : sig
         ; dst : Path_in_repo.t
         ; similarity : int
         }
-  [@@deriving sexp_of]
+  [@@deriving_inline sexp_of]
+
+  val sexp_of_t : t -> Sexplib0.Sexp.t
+
+  [@@@deriving.end]
 
   val equal : t -> t -> bool
 end
 
-type t = Change.t list [@@deriving sexp_of]
+type t = Change.t list [@@deriving_inline sexp_of]
+
+val sexp_of_t : t -> Sexplib0.Sexp.t
+
+[@@@deriving.end]
 
 (** Returns the set of files that are involved by the changes, either at [src]
     or [dst]. *)
@@ -81,7 +89,11 @@ module Changed : sig
         { src : Rev.t
         ; dst : Rev.t
         }
-  [@@deriving sexp_of]
+  [@@deriving_inline sexp_of]
+
+  val sexp_of_t : t -> Sexplib0.Sexp.t
+
+  [@@@deriving.end]
 
   val equal : t -> t -> bool
 end

--- a/lib/volgo/src/name_status.mli
+++ b/lib/volgo/src/name_status.mli
@@ -57,20 +57,14 @@ module Change : sig
         ; dst : Path_in_repo.t
         ; similarity : int
         }
-  [@@deriving_inline sexp_of]
 
-  val sexp_of_t : t -> Sexplib0.Sexp.t
-
-  [@@@deriving.end]
-
+  val sexp_of_t : t -> Sexp.t
   val equal : t -> t -> bool
 end
 
-type t = Change.t list [@@deriving_inline sexp_of]
+type t = Change.t list
 
 val sexp_of_t : t -> Sexplib0.Sexp.t
-
-[@@@deriving.end]
 
 (** Returns the set of files that are involved by the changes, either at [src]
     or [dst]. *)
@@ -89,11 +83,7 @@ module Changed : sig
         { src : Rev.t
         ; dst : Rev.t
         }
-  [@@deriving_inline sexp_of]
 
-  val sexp_of_t : t -> Sexplib0.Sexp.t
-
-  [@@@deriving.end]
-
+  val sexp_of_t : t -> Sexp.t
   val equal : t -> t -> bool
 end

--- a/lib/volgo/src/num_lines_in_diff.ml
+++ b/lib/volgo/src/num_lines_in_diff.ml
@@ -26,7 +26,26 @@ module T = struct
     { insertions : int
     ; deletions : int
     }
-  [@@deriving sexp_of]
+  [@@deriving_inline sexp_of]
+
+  let sexp_of_t =
+    (fun { insertions = insertions__002_; deletions = deletions__004_ } ->
+       let bnds__001_ = ([] : _ Stdlib.List.t) in
+       let bnds__001_ =
+         let arg__005_ = sexp_of_int deletions__004_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "deletions"; arg__005_ ] :: bnds__001_
+          : _ Stdlib.List.t)
+       in
+       let bnds__001_ =
+         let arg__003_ = sexp_of_int insertions__002_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "insertions"; arg__003_ ] :: bnds__001_
+          : _ Stdlib.List.t)
+       in
+       Sexplib0.Sexp.List bnds__001_
+     : t -> Sexplib0.Sexp.t)
+  ;;
+
+  [@@@deriving.end]
 
   let compare =
     (fun a__001_ b__002_ ->

--- a/lib/volgo/src/num_lines_in_diff.mli
+++ b/lib/volgo/src/num_lines_in_diff.mli
@@ -30,12 +30,8 @@ type t =
   { insertions : int
   ; deletions : int
   }
-[@@deriving_inline sexp_of]
 
-val sexp_of_t : t -> Sexplib0.Sexp.t
-
-[@@@deriving.end]
-
+val sexp_of_t : t -> Sexp.t
 val compare : t -> t -> int
 val equal : t -> t -> bool
 val zero : t

--- a/lib/volgo/src/num_lines_in_diff.mli
+++ b/lib/volgo/src/num_lines_in_diff.mli
@@ -30,7 +30,11 @@ type t =
   { insertions : int
   ; deletions : int
   }
-[@@deriving sexp_of]
+[@@deriving_inline sexp_of]
+
+val sexp_of_t : t -> Sexplib0.Sexp.t
+
+[@@@deriving.end]
 
 val compare : t -> t -> int
 val equal : t -> t -> bool

--- a/lib/volgo/src/num_status.ml
+++ b/lib/volgo/src/num_status.ml
@@ -30,7 +30,30 @@ module Key = struct
         { src : Path_in_repo.t
         ; dst : Path_in_repo.t
         }
-  [@@deriving sexp_of]
+  [@@deriving_inline sexp_of]
+
+  let sexp_of_t =
+    (function
+     | One_file arg0__001_ ->
+       let res0__002_ = Path_in_repo.sexp_of_t arg0__001_ in
+       Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "One_file"; res0__002_ ]
+     | Two_files { src = src__004_; dst = dst__006_ } ->
+       let bnds__003_ = ([] : _ Stdlib.List.t) in
+       let bnds__003_ =
+         let arg__007_ = Path_in_repo.sexp_of_t dst__006_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "dst"; arg__007_ ] :: bnds__003_
+          : _ Stdlib.List.t)
+       in
+       let bnds__003_ =
+         let arg__005_ = Path_in_repo.sexp_of_t src__004_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "src"; arg__005_ ] :: bnds__003_
+          : _ Stdlib.List.t)
+       in
+       Sexplib0.Sexp.List (Sexplib0.Sexp.Atom "Two_files" :: bnds__003_)
+     : t -> Sexplib0.Sexp.t)
+  ;;
+
+  [@@@deriving.end]
 
   let compare =
     (fun a__001_ b__002_ ->
@@ -74,7 +97,18 @@ module Change = struct
     type t =
       | Num_lines_in_diff of Num_lines_in_diff.t
       | Binary_file
-    [@@deriving sexp_of]
+    [@@deriving_inline sexp_of]
+
+    let sexp_of_t =
+      (function
+       | Num_lines_in_diff arg0__008_ ->
+         let res0__009_ = Num_lines_in_diff.sexp_of_t arg0__008_ in
+         Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "Num_lines_in_diff"; res0__009_ ]
+       | Binary_file -> Sexplib0.Sexp.Atom "Binary_file"
+       : t -> Sexplib0.Sexp.t)
+    ;;
+
+    [@@@deriving.end]
 
     let equal =
       (fun a__008_ b__009_ ->
@@ -95,7 +129,26 @@ module Change = struct
     { key : Key.t
     ; num_stat : Num_stat.t
     }
-  [@@deriving sexp_of]
+  [@@deriving_inline sexp_of]
+
+  let sexp_of_t =
+    (fun { key = key__011_; num_stat = num_stat__013_ } ->
+       let bnds__010_ = ([] : _ Stdlib.List.t) in
+       let bnds__010_ =
+         let arg__014_ = Num_stat.sexp_of_t num_stat__013_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "num_stat"; arg__014_ ] :: bnds__010_
+          : _ Stdlib.List.t)
+       in
+       let bnds__010_ =
+         let arg__012_ = Key.sexp_of_t key__011_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "key"; arg__012_ ] :: bnds__010_
+          : _ Stdlib.List.t)
+       in
+       Sexplib0.Sexp.List bnds__010_
+     : t -> Sexplib0.Sexp.t)
+  ;;
+
+  [@@@deriving.end]
 
   let equal =
     (fun a__014_ b__015_ ->
@@ -109,7 +162,13 @@ module Change = struct
 end
 
 module T = struct
-  type t = Change.t list [@@deriving sexp_of]
+  type t = Change.t list [@@deriving_inline sexp_of]
+
+  let sexp_of_t =
+    (fun x__015_ -> sexp_of_list Change.sexp_of_t x__015_ : t -> Sexplib0.Sexp.t)
+  ;;
+
+  [@@@deriving.end]
 end
 
 include T
@@ -122,7 +181,26 @@ module Changed = struct
         { src : Rev.t
         ; dst : Rev.t
         }
-  [@@deriving sexp_of]
+  [@@deriving_inline sexp_of]
+
+  let sexp_of_t =
+    (fun (Between { src = src__017_; dst = dst__019_ }) ->
+       let bnds__016_ = ([] : _ Stdlib.List.t) in
+       let bnds__016_ =
+         let arg__020_ = Rev.sexp_of_t dst__019_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "dst"; arg__020_ ] :: bnds__016_
+          : _ Stdlib.List.t)
+       in
+       let bnds__016_ =
+         let arg__018_ = Rev.sexp_of_t src__017_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "src"; arg__018_ ] :: bnds__016_
+          : _ Stdlib.List.t)
+       in
+       Sexplib0.Sexp.List (Sexplib0.Sexp.Atom "Between" :: bnds__016_)
+     : t -> Sexplib0.Sexp.t)
+  ;;
+
+  [@@@deriving.end]
 
   let equal =
     (fun a__022_ b__023_ ->

--- a/lib/volgo/src/num_status.mli
+++ b/lib/volgo/src/num_status.mli
@@ -39,7 +39,11 @@ module Change : sig
     type t =
       | Num_lines_in_diff of Num_lines_in_diff.t
       | Binary_file
-    [@@deriving sexp_of]
+    [@@deriving_inline sexp_of]
+
+    val sexp_of_t : t -> Sexplib0.Sexp.t
+
+    [@@@deriving.end]
 
     val equal : t -> t -> bool
   end
@@ -48,12 +52,20 @@ module Change : sig
     { key : Key.t
     ; num_stat : Num_stat.t
     }
-  [@@deriving sexp_of]
+  [@@deriving_inline sexp_of]
+
+  val sexp_of_t : t -> Sexplib0.Sexp.t
+
+  [@@@deriving.end]
 
   val equal : t -> t -> bool
 end
 
-type t = Change.t list [@@deriving sexp_of]
+type t = Change.t list [@@deriving_inline sexp_of]
+
+val sexp_of_t : t -> Sexplib0.Sexp.t
+
+[@@@deriving.end]
 
 module Changed : sig
   (** Specifies which {!type:Num_status.t} we want to compute. *)
@@ -62,7 +74,11 @@ module Changed : sig
         { src : Rev.t
         ; dst : Rev.t
         }
-  [@@deriving sexp_of]
+  [@@deriving_inline sexp_of]
+
+  val sexp_of_t : t -> Sexplib0.Sexp.t
+
+  [@@@deriving.end]
 
   val equal : t -> t -> bool
 end

--- a/lib/volgo/src/num_status.mli
+++ b/lib/volgo/src/num_status.mli
@@ -39,12 +39,8 @@ module Change : sig
     type t =
       | Num_lines_in_diff of Num_lines_in_diff.t
       | Binary_file
-    [@@deriving_inline sexp_of]
 
-    val sexp_of_t : t -> Sexplib0.Sexp.t
-
-    [@@@deriving.end]
-
+    val sexp_of_t : t -> Sexp.t
     val equal : t -> t -> bool
   end
 
@@ -52,20 +48,14 @@ module Change : sig
     { key : Key.t
     ; num_stat : Num_stat.t
     }
-  [@@deriving_inline sexp_of]
 
-  val sexp_of_t : t -> Sexplib0.Sexp.t
-
-  [@@@deriving.end]
-
+  val sexp_of_t : t -> Sexp.t
   val equal : t -> t -> bool
 end
 
-type t = Change.t list [@@deriving_inline sexp_of]
+type t = Change.t list
 
-val sexp_of_t : t -> Sexplib0.Sexp.t
-
-[@@@deriving.end]
+val sexp_of_t : t -> Sexp.t
 
 module Changed : sig
   (** Specifies which {!type:Num_status.t} we want to compute. *)
@@ -74,11 +64,7 @@ module Changed : sig
         { src : Rev.t
         ; dst : Rev.t
         }
-  [@@deriving_inline sexp_of]
 
-  val sexp_of_t : t -> Sexplib0.Sexp.t
-
-  [@@@deriving.end]
-
+  val sexp_of_t : t -> Sexp.t
   val equal : t -> t -> bool
 end

--- a/lib/volgo/src/platform.ml
+++ b/lib/volgo/src/platform.ml
@@ -27,7 +27,21 @@ type t =
   | GitHub
   | GitLab
   | Sourcehut
-[@@deriving enumerate, sexp_of]
+[@@deriving_inline enumerate, sexp_of]
+
+let all = ([ Bitbucket; Codeberg; GitHub; GitLab; Sourcehut ] : t list)
+
+let sexp_of_t =
+  (function
+   | Bitbucket -> Sexplib0.Sexp.Atom "Bitbucket"
+   | Codeberg -> Sexplib0.Sexp.Atom "Codeberg"
+   | GitHub -> Sexplib0.Sexp.Atom "GitHub"
+   | GitLab -> Sexplib0.Sexp.Atom "GitLab"
+   | Sourcehut -> Sexplib0.Sexp.Atom "Sourcehut"
+   : t -> Sexplib0.Sexp.t)
+;;
+
+[@@@deriving.end]
 
 let compare = (compare : t -> t -> int)
 let equal = (( = ) : t -> t -> bool)

--- a/lib/volgo/src/platform_repo.ml
+++ b/lib/volgo/src/platform_repo.ml
@@ -27,7 +27,18 @@ module Vcs_kind = struct
   type t =
     | Git
     | Hg
-  [@@deriving enumerate, sexp_of]
+  [@@deriving_inline enumerate, sexp_of]
+
+  let all = ([ Git; Hg ] : t list)
+
+  let sexp_of_t =
+    (function
+     | Git -> Sexplib0.Sexp.Atom "Git"
+     | Hg -> Sexplib0.Sexp.Atom "Hg"
+     : t -> Sexplib0.Sexp.t)
+  ;;
+
+  [@@@deriving.end]
 
   let compare = (Stdlib.compare : t -> t -> int)
   let equal = (( = ) : t -> t -> bool)
@@ -44,7 +55,40 @@ type t =
   ; user_handle : User_handle.t
   ; repo_name : Repo_name.t
   }
-[@@deriving sexp_of]
+[@@deriving_inline sexp_of]
+
+let sexp_of_t =
+  (fun { platform = platform__002_
+       ; vcs_kind = vcs_kind__004_
+       ; user_handle = user_handle__006_
+       ; repo_name = repo_name__008_
+       } ->
+     let bnds__001_ = ([] : _ Stdlib.List.t) in
+     let bnds__001_ =
+       let arg__009_ = Repo_name.sexp_of_t repo_name__008_ in
+       (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "repo_name"; arg__009_ ] :: bnds__001_
+        : _ Stdlib.List.t)
+     in
+     let bnds__001_ =
+       let arg__007_ = User_handle.sexp_of_t user_handle__006_ in
+       (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "user_handle"; arg__007_ ] :: bnds__001_
+        : _ Stdlib.List.t)
+     in
+     let bnds__001_ =
+       let arg__005_ = Vcs_kind.sexp_of_t vcs_kind__004_ in
+       (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "vcs_kind"; arg__005_ ] :: bnds__001_
+        : _ Stdlib.List.t)
+     in
+     let bnds__001_ =
+       let arg__003_ = Platform.sexp_of_t platform__002_ in
+       (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "platform"; arg__003_ ] :: bnds__001_
+        : _ Stdlib.List.t)
+     in
+     Sexplib0.Sexp.List bnds__001_
+   : t -> Sexplib0.Sexp.t)
+;;
+
+[@@@deriving.end]
 
 let compare = (Stdlib.compare : t -> t -> int)
 let equal = (( = ) : t -> t -> bool)
@@ -57,7 +101,18 @@ module Protocol = struct
   type t =
     | Ssh
     | Https
-  [@@deriving enumerate, sexp_of]
+  [@@deriving_inline enumerate, sexp_of]
+
+  let all = ([ Ssh; Https ] : t list)
+
+  let sexp_of_t =
+    (function
+     | Ssh -> Sexplib0.Sexp.Atom "Ssh"
+     | Https -> Sexplib0.Sexp.Atom "Https"
+     : t -> Sexplib0.Sexp.t)
+  ;;
+
+  [@@@deriving.end]
 
   let compare = (Stdlib.compare : t -> t -> int)
   let equal = (( = ) : t -> t -> bool)
@@ -72,7 +127,18 @@ module Ssh_syntax = struct
   type t =
     | Scp_like
     | Url_style
-  [@@deriving enumerate, sexp_of]
+  [@@deriving_inline enumerate, sexp_of]
+
+  let all = ([ Scp_like; Url_style ] : t list)
+
+  let sexp_of_t =
+    (function
+     | Scp_like -> Sexplib0.Sexp.Atom "Scp_like"
+     | Url_style -> Sexplib0.Sexp.Atom "Url_style"
+     : t -> Sexplib0.Sexp.t)
+  ;;
+
+  [@@@deriving.end]
 
   let compare = (Stdlib.compare : t -> t -> int)
   let equal = (( = ) : t -> t -> bool)
@@ -94,7 +160,46 @@ module Url = struct
     ; repo_name : Repo_name.t
     ; protocol : Protocol.t
     }
-  [@@deriving sexp_of]
+  [@@deriving_inline sexp_of]
+
+  let sexp_of_t =
+    (fun { platform = platform__011_
+         ; vcs_kind = vcs_kind__013_
+         ; user_handle = user_handle__015_
+         ; repo_name = repo_name__017_
+         ; protocol = protocol__019_
+         } ->
+       let bnds__010_ = ([] : _ Stdlib.List.t) in
+       let bnds__010_ =
+         let arg__020_ = Protocol.sexp_of_t protocol__019_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "protocol"; arg__020_ ] :: bnds__010_
+          : _ Stdlib.List.t)
+       in
+       let bnds__010_ =
+         let arg__018_ = Repo_name.sexp_of_t repo_name__017_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "repo_name"; arg__018_ ] :: bnds__010_
+          : _ Stdlib.List.t)
+       in
+       let bnds__010_ =
+         let arg__016_ = User_handle.sexp_of_t user_handle__015_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "user_handle"; arg__016_ ] :: bnds__010_
+          : _ Stdlib.List.t)
+       in
+       let bnds__010_ =
+         let arg__014_ = Vcs_kind.sexp_of_t vcs_kind__013_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "vcs_kind"; arg__014_ ] :: bnds__010_
+          : _ Stdlib.List.t)
+       in
+       let bnds__010_ =
+         let arg__012_ = Platform.sexp_of_t platform__011_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "platform"; arg__012_ ] :: bnds__010_
+          : _ Stdlib.List.t)
+       in
+       Sexplib0.Sexp.List bnds__010_
+     : t -> Sexplib0.Sexp.t)
+  ;;
+
+  [@@@deriving.end]
 
   let compare = (Stdlib.compare : t -> t -> int)
   let equal = (( = ) : t -> t -> bool)

--- a/lib/volgo/src/process_output.ml
+++ b/lib/volgo/src/process_output.ml
@@ -27,7 +27,31 @@ module T = struct
     ; stdout : string
     ; stderr : string
     }
-  [@@deriving sexp_of]
+  [@@deriving_inline sexp_of]
+
+  let sexp_of_t =
+    (fun { exit_code = exit_code__002_; stdout = stdout__004_; stderr = stderr__006_ } ->
+       let bnds__001_ = ([] : _ Stdlib.List.t) in
+       let bnds__001_ =
+         let arg__007_ = sexp_of_string stderr__006_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "stderr"; arg__007_ ] :: bnds__001_
+          : _ Stdlib.List.t)
+       in
+       let bnds__001_ =
+         let arg__005_ = sexp_of_string stdout__004_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "stdout"; arg__005_ ] :: bnds__001_
+          : _ Stdlib.List.t)
+       in
+       let bnds__001_ =
+         let arg__003_ = sexp_of_int exit_code__002_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "exit_code"; arg__003_ ] :: bnds__001_
+          : _ Stdlib.List.t)
+       in
+       Sexplib0.Sexp.List bnds__001_
+     : t -> Sexplib0.Sexp.t)
+  ;;
+
+  [@@@deriving.end]
 end
 
 include T

--- a/lib/volgo/src/process_output.mli
+++ b/lib/volgo/src/process_output.mli
@@ -31,11 +31,8 @@ type t =
   ; stdout : string
   ; stderr : string
   }
-[@@deriving_inline sexp_of]
 
-val sexp_of_t : t -> Sexplib0.Sexp.t
-
-[@@@deriving.end]
+val sexp_of_t : t -> Sexp.t
 
 module Private : sig
   (** Exported for use by Git and Hg outputs. *)

--- a/lib/volgo/src/process_output.mli
+++ b/lib/volgo/src/process_output.mli
@@ -31,7 +31,11 @@ type t =
   ; stdout : string
   ; stderr : string
   }
-[@@deriving sexp_of]
+[@@deriving_inline sexp_of]
+
+val sexp_of_t : t -> Sexplib0.Sexp.t
+
+[@@@deriving.end]
 
 module Private : sig
   (** Exported for use by Git and Hg outputs. *)

--- a/lib/volgo/src/process_output_handler_intf.mli
+++ b/lib/volgo/src/process_output_handler_intf.mli
@@ -29,11 +29,8 @@ module type S = sig
       ; stdout : string
       ; stderr : string
       }
-    [@@deriving_inline sexp_of]
 
-    val sexp_of_t : t -> Sexplib0.Sexp.t
-
-    [@@@deriving.end]
+    val sexp_of_t : t -> Sexp.t
 
     module Private : sig
       val of_process_output : Process_output.t -> t

--- a/lib/volgo/src/process_output_handler_intf.mli
+++ b/lib/volgo/src/process_output_handler_intf.mli
@@ -29,7 +29,11 @@ module type S = sig
       ; stdout : string
       ; stderr : string
       }
-    [@@deriving sexp_of]
+    [@@deriving_inline sexp_of]
+
+    val sexp_of_t : t -> Sexplib0.Sexp.t
+
+    [@@@deriving.end]
 
     module Private : sig
       val of_process_output : Process_output.t -> t

--- a/lib/volgo/src/ref_kind.ml
+++ b/lib/volgo/src/ref_kind.ml
@@ -28,7 +28,47 @@ type t =
   | Remote_branch of { remote_branch_name : Remote_branch_name.t }
   | Tag of { tag_name : Tag_name.t }
   | Other of { name : string }
-[@@deriving sexp_of]
+[@@deriving_inline sexp_of]
+
+let sexp_of_t =
+  (function
+   | Local_branch { branch_name = branch_name__002_ } ->
+     let bnds__001_ = ([] : _ Stdlib.List.t) in
+     let bnds__001_ =
+       let arg__003_ = Branch_name.sexp_of_t branch_name__002_ in
+       (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "branch_name"; arg__003_ ] :: bnds__001_
+        : _ Stdlib.List.t)
+     in
+     Sexplib0.Sexp.List (Sexplib0.Sexp.Atom "Local_branch" :: bnds__001_)
+   | Remote_branch { remote_branch_name = remote_branch_name__005_ } ->
+     let bnds__004_ = ([] : _ Stdlib.List.t) in
+     let bnds__004_ =
+       let arg__006_ = Remote_branch_name.sexp_of_t remote_branch_name__005_ in
+       (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "remote_branch_name"; arg__006_ ]
+        :: bnds__004_
+        : _ Stdlib.List.t)
+     in
+     Sexplib0.Sexp.List (Sexplib0.Sexp.Atom "Remote_branch" :: bnds__004_)
+   | Tag { tag_name = tag_name__008_ } ->
+     let bnds__007_ = ([] : _ Stdlib.List.t) in
+     let bnds__007_ =
+       let arg__009_ = Tag_name.sexp_of_t tag_name__008_ in
+       (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "tag_name"; arg__009_ ] :: bnds__007_
+        : _ Stdlib.List.t)
+     in
+     Sexplib0.Sexp.List (Sexplib0.Sexp.Atom "Tag" :: bnds__007_)
+   | Other { name = name__011_ } ->
+     let bnds__010_ = ([] : _ Stdlib.List.t) in
+     let bnds__010_ =
+       let arg__012_ = sexp_of_string name__011_ in
+       (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "name"; arg__012_ ] :: bnds__010_
+        : _ Stdlib.List.t)
+     in
+     Sexplib0.Sexp.List (Sexplib0.Sexp.Atom "Other" :: bnds__010_)
+   : t -> Sexplib0.Sexp.t)
+;;
+
+[@@@deriving.end]
 
 let compare =
   (fun a__001_ b__002_ ->

--- a/lib/volgo/src/refs.ml
+++ b/lib/volgo/src/refs.ml
@@ -28,7 +28,26 @@ module Line = struct
     { rev : Rev.t
     ; ref_kind : Ref_kind.t
     }
-  [@@deriving sexp_of]
+  [@@deriving_inline sexp_of]
+
+  let sexp_of_t =
+    (fun { rev = rev__002_; ref_kind = ref_kind__004_ } ->
+       let bnds__001_ = ([] : _ Stdlib.List.t) in
+       let bnds__001_ =
+         let arg__005_ = Ref_kind.sexp_of_t ref_kind__004_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "ref_kind"; arg__005_ ] :: bnds__001_
+          : _ Stdlib.List.t)
+       in
+       let bnds__001_ =
+         let arg__003_ = Rev.sexp_of_t rev__002_ in
+         (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "rev"; arg__003_ ] :: bnds__001_
+          : _ Stdlib.List.t)
+       in
+       Sexplib0.Sexp.List bnds__001_
+     : t -> Sexplib0.Sexp.t)
+  ;;
+
+  [@@@deriving.end]
 
   let equal =
     (fun a__001_ b__002_ ->
@@ -44,7 +63,13 @@ end
 module T = struct
   [@@@coverage off]
 
-  type t = Line.t list [@@deriving sexp_of]
+  type t = Line.t list [@@deriving_inline sexp_of]
+
+  let sexp_of_t =
+    (fun x__006_ -> sexp_of_list Line.sexp_of_t x__006_ : t -> Sexplib0.Sexp.t)
+  ;;
+
+  [@@@deriving.end]
 
   let equal a b = equal_list Line.equal a b
 end

--- a/lib/volgo/src/refs.mli
+++ b/lib/volgo/src/refs.mli
@@ -34,21 +34,14 @@ module Line : sig
     { rev : Rev.t
     ; ref_kind : Ref_kind.t
     }
-  [@@deriving_inline sexp_of]
 
-  val sexp_of_t : t -> Sexplib0.Sexp.t
-
-  [@@@deriving.end]
-
+  val sexp_of_t : t -> Sexp.t
   val equal : t -> t -> bool
 end
 
-type t = Line.t list [@@deriving_inline sexp_of]
+type t = Line.t list
 
-val sexp_of_t : t -> Sexplib0.Sexp.t
-
-[@@@deriving.end]
-
+val sexp_of_t : t -> Sexp.t
 val equal : t -> t -> bool
 
 (** {1 Accessors} *)

--- a/lib/volgo/src/refs.mli
+++ b/lib/volgo/src/refs.mli
@@ -34,12 +34,20 @@ module Line : sig
     { rev : Rev.t
     ; ref_kind : Ref_kind.t
     }
-  [@@deriving sexp_of]
+  [@@deriving_inline sexp_of]
+
+  val sexp_of_t : t -> Sexplib0.Sexp.t
+
+  [@@@deriving.end]
 
   val equal : t -> t -> bool
 end
 
-type t = Line.t list [@@deriving sexp_of]
+type t = Line.t list [@@deriving_inline sexp_of]
+
+val sexp_of_t : t -> Sexplib0.Sexp.t
+
+[@@@deriving.end]
 
 val equal : t -> t -> bool
 

--- a/lib/volgo/src/remote_branch_name.ml
+++ b/lib/volgo/src/remote_branch_name.ml
@@ -27,7 +27,26 @@ type t =
   { remote_name : Remote_name.t
   ; branch_name : Branch_name.t
   }
-[@@deriving sexp_of]
+[@@deriving_inline sexp_of]
+
+let sexp_of_t =
+  (fun { remote_name = remote_name__002_; branch_name = branch_name__004_ } ->
+     let bnds__001_ = ([] : _ Stdlib.List.t) in
+     let bnds__001_ =
+       let arg__005_ = Branch_name.sexp_of_t branch_name__004_ in
+       (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "branch_name"; arg__005_ ] :: bnds__001_
+        : _ Stdlib.List.t)
+     in
+     let bnds__001_ =
+       let arg__003_ = Remote_name.sexp_of_t remote_name__002_ in
+       (Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "remote_name"; arg__003_ ] :: bnds__001_
+        : _ Stdlib.List.t)
+     in
+     Sexplib0.Sexp.List bnds__001_
+   : t -> Sexplib0.Sexp.t)
+;;
+
+[@@@deriving.end]
 
 let compare =
   (fun a__001_ b__002_ ->

--- a/lib/volgo/src/vcs0.ml
+++ b/lib/volgo/src/vcs0.ml
@@ -128,7 +128,8 @@ let current_branch_opt (t : < Trait.current_branch ; .. > t) ~repo_root =
          (lazy
            (step_trace
               "Vcs.current_branch_opt"
-              [ sexp_field (module Repo_root) "repo_root" repo_root ]))
+              [ sexp_field (module Repo_root) "repo_root" repo_root ])
+           [@coverage off])
 ;;
 
 let current_revision (t : < Trait.current_revision ; .. > t) ~repo_root =
@@ -234,7 +235,8 @@ let graph (t : < Trait.log ; Trait.refs ; .. > t) ~repo_root =
          (lazy
            (step_trace
               "Vcs.graph"
-              [ sexp_field (module Repo_root) "repo_root" repo_root ]))
+              [ sexp_field (module Repo_root) "repo_root" repo_root ])
+           [@coverage off])
 ;;
 
 let set_user_name (t : < Trait.config ; .. > t) ~repo_root ~user_name =

--- a/lib/volgo/src/vcs_result.ml
+++ b/lib/volgo/src/vcs_result.ml
@@ -21,19 +21,15 @@
 
 open! Import
 
-type err = Err.t [@@deriving_inline sexp_of]
+type err = Err.t
 
-let sexp_of_err = (Err.sexp_of_t : err -> Sexplib0.Sexp.t)
+let sexp_of_err = Err.sexp_of_t
 
-[@@@deriving.end]
-
-type 'a t = ('a, err) Result.t [@@deriving_inline sexp_of]
+type 'a t = ('a, err) Result.t
 
 let sexp_of_t : 'a. ('a -> Sexplib0.Sexp.t) -> 'a t -> Sexplib0.Sexp.t =
   fun _of_a__001_ -> fun x__002_ -> Result.sexp_of_t _of_a__001_ sexp_of_err x__002_
 ;;
-
-[@@@deriving.end]
 
 module Non_raising_M = struct
   type t = err

--- a/lib/volgo/src/vcs_result.ml
+++ b/lib/volgo/src/vcs_result.ml
@@ -21,8 +21,19 @@
 
 open! Import
 
-type err = Err.t [@@deriving sexp_of]
-type 'a t = ('a, err) Result.t [@@deriving sexp_of]
+type err = Err.t [@@deriving_inline sexp_of]
+
+let sexp_of_err = (Err.sexp_of_t : err -> Sexplib0.Sexp.t)
+
+[@@@deriving.end]
+
+type 'a t = ('a, err) Result.t [@@deriving_inline sexp_of]
+
+let sexp_of_t : 'a. ('a -> Sexplib0.Sexp.t) -> 'a t -> Sexplib0.Sexp.t =
+  fun _of_a__001_ -> fun x__002_ -> Result.sexp_of_t _of_a__001_ sexp_of_err x__002_
+;;
+
+[@@@deriving.end]
 
 module Non_raising_M = struct
   type t = err

--- a/lib/volgo/src/vcs_result.mli
+++ b/lib/volgo/src/vcs_result.mli
@@ -21,8 +21,17 @@
 
 (** An [Vcs] API based on [Result] and [Vcs.Err]. *)
 
-type err = Err.t [@@deriving sexp_of]
-type 'a t = ('a, err) Result.t [@@deriving sexp_of]
+type err = Err.t [@@deriving_inline sexp_of]
+
+val sexp_of_err : err -> Sexplib0.Sexp.t
+
+[@@@deriving.end]
+
+type 'a t = ('a, err) Result.t [@@deriving_inline sexp_of]
+
+val sexp_of_t : ('a -> Sexplib0.Sexp.t) -> 'a t -> Sexplib0.Sexp.t
+
+[@@@deriving.end]
 
 (** {1 Non raising API}
 

--- a/lib/volgo/src/vcs_result.mli
+++ b/lib/volgo/src/vcs_result.mli
@@ -21,17 +21,13 @@
 
 (** An [Vcs] API based on [Result] and [Vcs.Err]. *)
 
-type err = Err.t [@@deriving_inline sexp_of]
+type err = Err.t
 
-val sexp_of_err : err -> Sexplib0.Sexp.t
+val sexp_of_err : err -> Sexp.t
 
-[@@@deriving.end]
+type 'a t = ('a, err) Result.t
 
-type 'a t = ('a, err) Result.t [@@deriving_inline sexp_of]
-
-val sexp_of_t : ('a -> Sexplib0.Sexp.t) -> 'a t -> Sexplib0.Sexp.t
-
-[@@@deriving.end]
+val sexp_of_t : ('a -> Sexp.t) -> 'a t -> Sexp.t
 
 (** {1 Non raising API}
 

--- a/lib/volgo/src/vcs_rresult.ml
+++ b/lib/volgo/src/vcs_rresult.ml
@@ -21,19 +21,15 @@
 
 open! Import
 
-type err = Vcs_rresult0.t [@@deriving_inline sexp_of]
+type err = Vcs_rresult0.t
 
-let sexp_of_err = (Vcs_rresult0.sexp_of_t : err -> Sexplib0.Sexp.t)
+let sexp_of_err = Vcs_rresult0.sexp_of_t
 
-[@@@deriving.end]
-
-type 'a t = ('a, err) Result.t [@@deriving_inline sexp_of]
+type 'a t = ('a, err) Result.t
 
 let sexp_of_t : 'a. ('a -> Sexplib0.Sexp.t) -> 'a t -> Sexplib0.Sexp.t =
   fun _of_a__001_ -> fun x__002_ -> Result.sexp_of_t _of_a__001_ sexp_of_err x__002_
 ;;
-
-[@@@deriving.end]
 
 type 'a result = 'a t
 

--- a/lib/volgo/src/vcs_rresult.ml
+++ b/lib/volgo/src/vcs_rresult.ml
@@ -21,8 +21,20 @@
 
 open! Import
 
-type err = Vcs_rresult0.t [@@deriving sexp_of]
-type 'a t = ('a, err) Result.t [@@deriving sexp_of]
+type err = Vcs_rresult0.t [@@deriving_inline sexp_of]
+
+let sexp_of_err = (Vcs_rresult0.sexp_of_t : err -> Sexplib0.Sexp.t)
+
+[@@@deriving.end]
+
+type 'a t = ('a, err) Result.t [@@deriving_inline sexp_of]
+
+let sexp_of_t : 'a. ('a -> Sexplib0.Sexp.t) -> 'a t -> Sexplib0.Sexp.t =
+  fun _of_a__001_ -> fun x__002_ -> Result.sexp_of_t _of_a__001_ sexp_of_err x__002_
+;;
+
+[@@@deriving.end]
+
 type 'a result = 'a t
 
 include Non_raising.Make (Vcs_rresult0)

--- a/lib/volgo/src/vcs_rresult.mli
+++ b/lib/volgo/src/vcs_rresult.mli
@@ -22,17 +22,13 @@
 (** An [Vcs] API in the style of
     {{:https://erratique.ch/software/rresult/doc/Rresult/index.html#usage} Rresult}. *)
 
-type err = [ `Vcs of Err.t ] [@@deriving_inline sexp_of]
+type err = [ `Vcs of Err.t ]
 
-val sexp_of_err : err -> Sexplib0.Sexp.t
+val sexp_of_err : err -> Sexp.t
 
-[@@@deriving.end]
+type 'a t = ('a, err) Result.t
 
-type 'a t = ('a, err) Result.t [@@deriving_inline sexp_of]
-
-val sexp_of_t : ('a -> Sexplib0.Sexp.t) -> 'a t -> Sexplib0.Sexp.t
-
-[@@@deriving.end]
+val sexp_of_t : ('a -> Sexp.t) -> 'a t -> Sexp.t
 
 type 'a result = 'a t
 

--- a/lib/volgo/src/vcs_rresult.mli
+++ b/lib/volgo/src/vcs_rresult.mli
@@ -22,8 +22,18 @@
 (** An [Vcs] API in the style of
     {{:https://erratique.ch/software/rresult/doc/Rresult/index.html#usage} Rresult}. *)
 
-type err = [ `Vcs of Err.t ] [@@deriving sexp_of]
-type 'a t = ('a, err) Result.t [@@deriving sexp_of]
+type err = [ `Vcs of Err.t ] [@@deriving_inline sexp_of]
+
+val sexp_of_err : err -> Sexplib0.Sexp.t
+
+[@@@deriving.end]
+
+type 'a t = ('a, err) Result.t [@@deriving_inline sexp_of]
+
+val sexp_of_t : ('a -> Sexplib0.Sexp.t) -> 'a t -> Sexplib0.Sexp.t
+
+[@@@deriving.end]
+
 type 'a result = 'a t
 
 (** {1 Utils}

--- a/lib/volgo/src/vcs_rresult0.ml
+++ b/lib/volgo/src/vcs_rresult0.ml
@@ -19,7 +19,15 @@
 (*  <http://www.gnu.org/licenses/> and <https://spdx.org>, respectively.       *)
 (*******************************************************************************)
 
-type t = [ `Vcs of Err.t ] [@@deriving sexp_of]
+type t = [ `Vcs of Err.t ] [@@deriving_inline sexp_of]
+
+let sexp_of_t =
+  (fun (`Vcs v__001_) ->
+     Sexplib0.Sexp.List [ Sexplib0.Sexp.Atom "Vcs"; Err.sexp_of_t v__001_ ]
+   : t -> Sexplib0.Sexp.t)
+;;
+
+[@@@deriving.end]
 
 let of_err err = `Vcs err
 let to_err (`Vcs err) = err

--- a/lib/volgo_hg_unix/test/test__hello_cli.ml
+++ b/lib/volgo_hg_unix/test/test__hello_cli.ml
@@ -103,6 +103,39 @@ let%expect_test "hello cli" =
      (error "Expected exit code 0."))
     |}];
   let () =
+    match
+      Vcs.hg
+        vcs
+        ~env:[| "HELLO=env" |]
+        ~run_in_subdir:Vcs.Path_in_repo.root
+        ~repo_root
+        ~args:[ "bogus" ]
+        ~f:Vcs.Hg.exit0
+    with
+    | _ -> assert false
+    | exception Err.E err ->
+      print_s
+        (Vcs_test_helpers.redact_sexp
+           [%sexp (err : Err.t)]
+           ~fields:[ "cwd"; "prog"; "repo_root"; "stderr" ])
+  in
+  [%expect
+    {|
+    ((context
+       (Vcs.hg
+         (repo_root     <REDACTED>)
+         (run_in_subdir ./)
+         (env  (HELLO=env))
+         (args (bogus)))
+       ((prog <REDACTED>)
+        (args (bogus))
+        (exit_status (Exited 255))
+        (cwd    <REDACTED>)
+        (stdout "")
+        (stderr <REDACTED>)))
+     (error "Expected exit code 0."))
+    |}];
+  let () =
     match Vcs.Result.hg vcs ~repo_root ~args:[ "bogus" ] ~f:Vcs.Hg.Result.exit0 with
     | Ok _ -> assert false
     | Error err ->

--- a/volgo.opam
+++ b/volgo.opam
@@ -15,9 +15,6 @@ depends: [
   "fpath-sexp0" {>= "0.3.1"}
   "pp" {>= "2.0.0"}
   "pplumbing" {>= "0.0.14"}
-  "ppx_enumerate" {>= "v0.16"}
-  "ppx_sexp_conv" {>= "v0.16"}
-  "ppxlib" {>= "0.33"}
   "sexplib0" {>= "v0.16"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
- Simplify dependencies of preprocessor in the kernel lib `volgo/src`.
- Make use of deriving_inline

There are still some issues that needs to be worked around due to formatting unstability. This is left as future work.