### PR TITLE
Use pplumbing sub pkgs directly

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -3,6 +3,6 @@
  (public_name volgo-vcs)
  (package volgo-vcs)
  (flags :standard -w +a-4-40-41-42-44-45-48-66 -warn-error +a)
- (libraries pplumbing.cmdlang-cmdliner-runner volgo-vcs.volgo-vcs-cli)
+ (libraries cmdlang-cmdliner-err-runner volgo-vcs.volgo-vcs-cli)
  (instrumentation
   (backend bisect_ppx)))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -20,5 +20,8 @@
 (*******************************************************************************)
 
 let () =
-  Cmdlang_cmdliner_runner.run Volgo_vcs_cli.main ~name:"volgo-vcs" ~version:"%%VERSION%%"
+  Cmdlang_cmdliner_err_runner.run
+    Volgo_vcs_cli.main
+    ~name:"volgo-vcs"
+    ~version:"%%VERSION%%"
 ;;

--- a/dune-project
+++ b/dune-project
@@ -45,8 +45,10 @@
    (>= 0.3.1))
   (pp
    (>= 2.0.0))
-  (pplumbing
-   (>= 0.0.14))
+  (pplumbing-err
+   (>= 0.0.16))
+  (pplumbing-pp-tty
+   (>= 0.0.16))
   (sexplib0
    (>= v0.16))))
 
@@ -64,8 +66,10 @@
    (>= 0.3.1))
   (pp
    (>= 2.0.0))
-  (pplumbing
-   (>= 0.0.14))
+  (pplumbing-err
+   (>= 0.0.16))
+  (pplumbing-pp-tty
+   (>= 0.0.16))
   (ppx_compare
    (>= v0.17))
   (ppx_enumerate
@@ -94,6 +98,8 @@
    (>= 4.14))
   (cmdlang
    (>= 0.0.9))
+  (cmdlang-cmdliner-err-runner
+   (>= 0.0.16))
   (conf-git :with-test)
   (conf-hg :with-test)
   (fpath
@@ -102,8 +108,10 @@
    (>= 0.3.1))
   (pp
    (>= 2.0.0))
-  (pplumbing
-   (>= 0.0.14))
+  (pplumbing-err
+   (>= 0.0.16))
+  (pplumbing-pp-tty
+   (>= 0.0.16))
   (sexplib0
    (>= v0.16))
   (volgo
@@ -131,8 +139,10 @@
    (>= 0.3.1))
   (pp
    (>= 2.0.0))
-  (pplumbing
-   (>= 0.0.14))
+  (pplumbing-err
+   (>= 0.0.16))
+  (pplumbing-pp-tty
+   (>= 0.0.16))
   (sexplib0
    (>= v0.16))
   (volgo
@@ -152,8 +162,10 @@
    (>= 0.3.1))
   (pp
    (>= 2.0.0))
-  (pplumbing
-   (>= 0.0.14))
+  (pplumbing-err
+   (>= 0.0.16))
+  (pplumbing-pp-tty
+   (>= 0.0.16))
   (sexplib0
    (>= v0.16))
   (volgo
@@ -175,8 +187,10 @@
    (>= 0.3.1))
   (pp
    (>= 2.0.0))
-  (pplumbing
-   (>= 0.0.14))
+  (pplumbing-err
+   (>= 0.0.16))
+  (pplumbing-pp-tty
+   (>= 0.0.16))
   (sexplib0
    (>= v0.17))
   (volgo
@@ -200,8 +214,10 @@
    (>= 0.3.1))
   (pp
    (>= 2.0.0))
-  (pplumbing
-   (>= 0.0.14))
+  (pplumbing-err
+   (>= 0.0.16))
+  (pplumbing-pp-tty
+   (>= 0.0.16))
   (sexplib0
    (>= v0.17))
   (volgo
@@ -225,8 +241,10 @@
    (>= 0.3.1))
   (pp
    (>= 2.0.0))
-  (pplumbing
-   (>= 0.0.14))
+  (pplumbing-err
+   (>= 0.0.16))
+  (pplumbing-pp-tty
+   (>= 0.0.16))
   (sexplib0
    (>= v0.16))
   (spawn
@@ -250,8 +268,10 @@
    (>= 0.3.1))
   (pp
    (>= 2.0.0))
-  (pplumbing
-   (>= 0.0.14))
+  (pplumbing-err
+   (>= 0.0.16))
+  (pplumbing-pp-tty
+   (>= 0.0.16))
   (sexplib0
    (>= v0.16))
   (volgo
@@ -277,8 +297,10 @@
    (>= 0.3.1))
   (pp
    (>= 2.0.0))
-  (pplumbing
-   (>= 0.0.14))
+  (pplumbing-err
+   (>= 0.0.16))
+  (pplumbing-pp-tty
+   (>= 0.0.16))
   (ppx_compare
    (>= v0.17))
   (ppx_enumerate
@@ -324,6 +346,8 @@
    (>= 2.1))
   (cmdlang
    (>= 0.0.9))
+  (cmdlang-cmdliner-err-runner
+   (>= 0.0.16))
   conf-git
   conf-hg
   (core
@@ -346,8 +370,10 @@
     (>= 2.4)))
   (pp
    (>= 2.0.0))
-  (pplumbing
-   (>= 0.0.14))
+  (pplumbing-err
+   (>= 0.0.16))
+  (pplumbing-pp-tty
+   (>= 0.0.16))
   (ppx_compare
    (>= v0.17))
   (ppx_enumerate
@@ -433,6 +459,8 @@
    (>= 2.1))
   (cmdlang
    (>= 0.0.9))
+  (cmdlang-cmdliner-err-runner
+   (>= 0.0.16))
   conf-git
   conf-hg
   (core
@@ -453,8 +481,10 @@
    (>= 2.4))
   (pp
    (>= 2.0.0))
-  (pplumbing
-   (>= 0.0.14))
+  (pplumbing-err
+   (>= 0.0.16))
+  (pplumbing-pp-tty
+   (>= 0.0.16))
   (ppx_compare
    (>= v0.17))
   (ppx_enumerate

--- a/example/dune
+++ b/example/dune
@@ -13,6 +13,8 @@
   -open
   Fpath_sexp0
   -open
+  Pplumbing_err
+  -open
   Expect_test_helpers_base
   -open
   Volgo_base)
@@ -24,7 +26,7 @@
   fpath
   fpath-sexp0
   pp
-  pplumbing.err
+  pplumbing-err
   unix
   vcs_test_helpers
   volgo_base

--- a/lib/vcs_test_helpers/test/dune
+++ b/lib/vcs_test_helpers/test/dune
@@ -13,6 +13,8 @@
   -open
   Fpath_sexp0
   -open
+  Pplumbing_err
+  -open
   Expect_test_helpers_base
   -open
   Volgo)
@@ -24,7 +26,7 @@
   fpath
   fpath-sexp0
   pp
-  pplumbing.err
+  pplumbing-err
   vcs_test_helpers
   volgo
   volgo_git_eio)

--- a/lib/volgo/src/dune
+++ b/lib/volgo/src/dune
@@ -10,6 +10,10 @@
   -open
   Fpath_sexp0
   -open
+  Pplumbing_pp_tty
+  -open
+  Pplumbing_err
+  -open
   Sexplib0
   -open
   Sexplib0.Sexp_conv)
@@ -19,8 +23,8 @@
   fpath
   fpath-sexp0
   pp
-  pplumbing.err
-  pplumbing.pp-tty
+  pplumbing-err
+  pplumbing-pp-tty
   sexplib0)
  (modules
   (:standard \ stdlib_compat4xx stdlib_compat5xx))

--- a/lib/volgo/test/dune
+++ b/lib/volgo/test/dune
@@ -18,6 +18,8 @@
   -open
   Fpath_sexp0
   -open
+  Pplumbing_err
+  -open
   Expect_test_helpers_base
   -open
   Volgo)
@@ -30,7 +32,7 @@
   fpath
   fpath-sexp0
   pp
-  pplumbing.err
+  pplumbing-err
   volgo
   volgo_base
   volgo_git_backend)

--- a/lib/volgo_base/src/dune
+++ b/lib/volgo_base/src/dune
@@ -12,8 +12,10 @@
   -open
   Fpath_base
   -open
+  Pplumbing_err
+  -open
   Volgo)
- (libraries base fpath fpath-base pp pplumbing.err volgo)
+ (libraries base fpath fpath-base pp pplumbing-err volgo)
  (instrumentation
   (backend bisect_ppx))
  (lint

--- a/lib/volgo_base/test/dune
+++ b/lib/volgo_base/test/dune
@@ -16,6 +16,8 @@
   -open
   Base
   -open
+  Pplumbing_err
+  -open
   Fpath_sexp0
   -open
   Expect_test_helpers_base
@@ -29,7 +31,7 @@
   fpath
   fpath-sexp0
   pp
-  pplumbing.err
+  pplumbing-err
   volgo
   volgo_base
   volgo_git_backend)

--- a/lib/volgo_git_backend/src/dune
+++ b/lib/volgo_git_backend/src/dune
@@ -10,6 +10,10 @@
   -open
   Fpath_sexp0
   -open
+  Pplumbing_pp_tty
+  -open
+  Pplumbing_err
+  -open
   Sexplib0
   -open
   Sexplib0.Sexp_conv
@@ -20,8 +24,8 @@
   fpath
   fpath-sexp0
   pp
-  pplumbing.err
-  pplumbing.pp-tty
+  pplumbing-err
+  pplumbing-pp-tty
   sexplib0
   volgo)
  (instrumentation

--- a/lib/volgo_git_eio/src/dune
+++ b/lib/volgo_git_eio/src/dune
@@ -10,6 +10,8 @@
   -open
   Fpath_sexp0
   -open
+  Pplumbing_err
+  -open
   Sexplib0
   -open
   Sexplib0.Sexp_conv
@@ -20,7 +22,7 @@
   fpath
   fpath-sexp0
   pp
-  pplumbing.err
+  pplumbing-err
   sexplib0
   volgo
   volgo-git-backend)

--- a/lib/volgo_git_eio/test/dune
+++ b/lib/volgo_git_eio/test/dune
@@ -13,6 +13,8 @@
   -open
   Fpath_sexp0
   -open
+  Pplumbing_err
+  -open
   Expect_test_helpers_base
   -open
   Volgo)
@@ -24,7 +26,7 @@
   fpath
   fpath-sexp0
   pp
-  pplumbing.err
+  pplumbing-err
   unix
   vcs_test_helpers
   volgo

--- a/lib/volgo_git_unix/src/dune
+++ b/lib/volgo_git_unix/src/dune
@@ -10,6 +10,10 @@
   -open
   Fpath_sexp0
   -open
+  Pplumbing_pp_tty
+  -open
+  Pplumbing_err
+  -open
   Sexplib0
   -open
   Sexplib0.Sexp_conv
@@ -19,8 +23,8 @@
   fpath
   fpath-sexp0
   pp
-  pplumbing.err
-  pplumbing.pp-tty
+  pplumbing-err
+  pplumbing-pp-tty
   sexplib0
   spawn
   unix

--- a/lib/volgo_git_unix/test/dune
+++ b/lib/volgo_git_unix/test/dune
@@ -13,6 +13,8 @@
   -open
   Fpath_sexp0
   -open
+  Pplumbing_err
+  -open
   Stdio
   -open
   Expect_test_helpers_base
@@ -24,7 +26,7 @@
   fpath
   fpath-sexp0
   pp
-  pplumbing.err
+  pplumbing-err
   stdio
   unix
   vcs_test_helpers

--- a/lib/volgo_hg_backend/src/dune
+++ b/lib/volgo_hg_backend/src/dune
@@ -10,6 +10,10 @@
   -open
   Fpath_sexp0
   -open
+  Pplumbing_pp_tty
+  -open
+  Pplumbing_err
+  -open
   Sexplib0
   -open
   Sexplib0.Sexp_conv
@@ -20,8 +24,8 @@
   fpath
   fpath-sexp0
   pp
-  pplumbing.err
-  pplumbing.pp-tty
+  pplumbing-err
+  pplumbing-pp-tty
   sexplib0
   volgo)
  (instrumentation

--- a/lib/volgo_hg_eio/src/dune
+++ b/lib/volgo_hg_eio/src/dune
@@ -10,6 +10,8 @@
   -open
   Fpath_sexp0
   -open
+  Pplumbing_err
+  -open
   Sexplib0
   -open
   Sexplib0.Sexp_conv
@@ -20,7 +22,7 @@
   fpath
   fpath-sexp0
   pp
-  pplumbing.err
+  pplumbing-err
   sexplib0
   volgo
   volgo-git-eio

--- a/lib/volgo_hg_eio/test/dune
+++ b/lib/volgo_hg_eio/test/dune
@@ -13,6 +13,8 @@
   -open
   Fpath_sexp0
   -open
+  Pplumbing_err
+  -open
   Expect_test_helpers_base
   -open
   Volgo)
@@ -24,7 +26,7 @@
   fpath
   fpath-sexp0
   pp
-  pplumbing.err
+  pplumbing-err
   unix
   vcs_test_helpers
   volgo

--- a/lib/volgo_hg_unix/src/dune
+++ b/lib/volgo_hg_unix/src/dune
@@ -10,6 +10,10 @@
   -open
   Fpath_sexp0
   -open
+  Pplumbing_pp_tty
+  -open
+  Pplumbing_err
+  -open
   Sexplib0
   -open
   Sexplib0.Sexp_conv
@@ -19,8 +23,8 @@
   fpath
   fpath-sexp0
   pp
-  pplumbing.err
-  pplumbing.pp-tty
+  pplumbing-err
+  pplumbing-pp-tty
   sexplib0
   unix
   volgo

--- a/lib/volgo_hg_unix/test/dune
+++ b/lib/volgo_hg_unix/test/dune
@@ -13,6 +13,8 @@
   -open
   Fpath_sexp0
   -open
+  Pplumbing_err
+  -open
   Stdio
   -open
   Expect_test_helpers_base
@@ -24,7 +26,7 @@
   fpath
   fpath-sexp0
   pp
-  pplumbing.err
+  pplumbing-err
   stdio
   unix
   vcs_test_helpers

--- a/lib/volgo_vcs_cli/src/dune
+++ b/lib/volgo_vcs_cli/src/dune
@@ -10,6 +10,10 @@
   -open
   Fpath_sexp0
   -open
+  Pplumbing_pp_tty
+  -open
+  Pplumbing_err
+  -open
   Cmdlang
   -open
   Sexplib0
@@ -21,8 +25,8 @@
   cmdlang
   fpath-sexp0
   pp
-  pplumbing.err
-  pplumbing.pp-tty
+  pplumbing-err
+  pplumbing-pp-tty
   sexplib0
   unix
   volgo

--- a/test/expect/dune
+++ b/test/expect/dune
@@ -13,6 +13,8 @@
   -open
   Fpath_sexp0
   -open
+  Pplumbing_err
+  -open
   Expect_test_helpers_base
   -open
   Volgo_base)
@@ -24,7 +26,7 @@
   fpath
   fpath-sexp0
   pp
-  pplumbing.err
+  pplumbing-err
   unix
   vcs_test_helpers
   volgo_base

--- a/vcs-test-helpers.opam
+++ b/vcs-test-helpers.opam
@@ -15,7 +15,8 @@ depends: [
   "fpath" {>= "0.7.3"}
   "fpath-sexp0" {>= "0.3.1"}
   "pp" {>= "2.0.0"}
-  "pplumbing" {>= "0.0.14"}
+  "pplumbing-err" {>= "0.0.16"}
+  "pplumbing-pp-tty" {>= "0.0.16"}
   "ppx_compare" {>= "v0.17"}
   "ppx_enumerate" {>= "v0.17"}
   "ppx_hash" {>= "v0.17"}

--- a/volgo-base.opam
+++ b/volgo-base.opam
@@ -14,7 +14,8 @@ depends: [
   "fpath" {>= "0.7.3"}
   "fpath-base" {>= "0.3.1"}
   "pp" {>= "2.0.0"}
-  "pplumbing" {>= "0.0.14"}
+  "pplumbing-err" {>= "0.0.16"}
+  "pplumbing-pp-tty" {>= "0.0.16"}
   "ppx_compare" {>= "v0.17"}
   "ppx_enumerate" {>= "v0.17"}
   "ppx_hash" {>= "v0.17"}

--- a/volgo-dev.opam
+++ b/volgo-dev.opam
@@ -18,6 +18,7 @@ depends: [
   "bisect_ppx" {with-dev-setup & >= "2.8.3"}
   "bitv" {>= "2.1"}
   "cmdlang" {>= "0.0.9"}
+  "cmdlang-cmdliner-err-runner" {>= "0.0.16"}
   "conf-git"
   "conf-hg"
   "core" {>= "v0.17"}
@@ -29,7 +30,8 @@ depends: [
   "fpath-sexp0" {>= "0.3.1"}
   "mdx" {>= "2.4"}
   "pp" {>= "2.0.0"}
-  "pplumbing" {>= "0.0.14"}
+  "pplumbing-err" {>= "0.0.16"}
+  "pplumbing-pp-tty" {>= "0.0.16"}
   "ppx_compare" {>= "v0.17"}
   "ppx_enumerate" {>= "v0.17"}
   "ppx_expect" {>= "v0.17"}

--- a/volgo-git-backend.opam
+++ b/volgo-git-backend.opam
@@ -14,7 +14,8 @@ depends: [
   "fpath" {>= "0.7.3"}
   "fpath-sexp0" {>= "0.3.1"}
   "pp" {>= "2.0.0"}
-  "pplumbing" {>= "0.0.14"}
+  "pplumbing-err" {>= "0.0.16"}
+  "pplumbing-pp-tty" {>= "0.0.16"}
   "sexplib0" {>= "v0.16"}
   "volgo" {= version}
   "odoc" {with-doc}

--- a/volgo-git-eio.opam
+++ b/volgo-git-eio.opam
@@ -15,7 +15,8 @@ depends: [
   "fpath" {>= "0.7.3"}
   "fpath-sexp0" {>= "0.3.1"}
   "pp" {>= "2.0.0"}
-  "pplumbing" {>= "0.0.14"}
+  "pplumbing-err" {>= "0.0.16"}
+  "pplumbing-pp-tty" {>= "0.0.16"}
   "sexplib0" {>= "v0.17"}
   "volgo" {= version}
   "volgo-git-backend" {= version}

--- a/volgo-git-unix.opam
+++ b/volgo-git-unix.opam
@@ -15,7 +15,8 @@ depends: [
   "fpath" {>= "0.7.3"}
   "fpath-sexp0" {>= "0.3.1"}
   "pp" {>= "2.0.0"}
-  "pplumbing" {>= "0.0.14"}
+  "pplumbing-err" {>= "0.0.16"}
+  "pplumbing-pp-tty" {>= "0.0.16"}
   "sexplib0" {>= "v0.16"}
   "spawn" {>= "v0.16"}
   "volgo" {= version}

--- a/volgo-hg-backend.opam
+++ b/volgo-hg-backend.opam
@@ -14,7 +14,8 @@ depends: [
   "fpath" {>= "0.7.3"}
   "fpath-sexp0" {>= "0.3.1"}
   "pp" {>= "2.0.0"}
-  "pplumbing" {>= "0.0.14"}
+  "pplumbing-err" {>= "0.0.16"}
+  "pplumbing-pp-tty" {>= "0.0.16"}
   "sexplib0" {>= "v0.16"}
   "volgo" {= version}
   "odoc" {with-doc}

--- a/volgo-hg-eio.opam
+++ b/volgo-hg-eio.opam
@@ -16,7 +16,8 @@ depends: [
   "fpath" {>= "0.7.3"}
   "fpath-sexp0" {>= "0.3.1"}
   "pp" {>= "2.0.0"}
-  "pplumbing" {>= "0.0.14"}
+  "pplumbing-err" {>= "0.0.16"}
+  "pplumbing-pp-tty" {>= "0.0.16"}
   "sexplib0" {>= "v0.17"}
   "volgo" {= version}
   "volgo-git-eio" {= version}

--- a/volgo-hg-unix.opam
+++ b/volgo-hg-unix.opam
@@ -15,7 +15,8 @@ depends: [
   "fpath" {>= "0.7.3"}
   "fpath-sexp0" {>= "0.3.1"}
   "pp" {>= "2.0.0"}
-  "pplumbing" {>= "0.0.14"}
+  "pplumbing-err" {>= "0.0.16"}
+  "pplumbing-pp-tty" {>= "0.0.16"}
   "sexplib0" {>= "v0.16"}
   "volgo" {= version}
   "volgo-git-unix" {= version}

--- a/volgo-tests.opam
+++ b/volgo-tests.opam
@@ -17,6 +17,7 @@ depends: [
   "bisect_ppx" {with-dev-setup & >= "2.8.3"}
   "bitv" {>= "2.1"}
   "cmdlang" {>= "0.0.9"}
+  "cmdlang-cmdliner-err-runner" {>= "0.0.16"}
   "conf-git"
   "conf-hg"
   "core" {>= "v0.17"}
@@ -28,7 +29,8 @@ depends: [
   "fpath-sexp0" {>= "0.3.1"}
   "mdx" {with-doc & >= "2.4"}
   "pp" {>= "2.0.0"}
-  "pplumbing" {>= "0.0.14"}
+  "pplumbing-err" {>= "0.0.16"}
+  "pplumbing-pp-tty" {>= "0.0.16"}
   "ppx_compare" {>= "v0.17"}
   "ppx_enumerate" {>= "v0.17"}
   "ppx_expect" {>= "v0.17"}

--- a/volgo-vcs.opam
+++ b/volgo-vcs.opam
@@ -12,12 +12,14 @@ depends: [
   "dune" {>= "3.17"}
   "ocaml" {>= "4.14"}
   "cmdlang" {>= "0.0.9"}
+  "cmdlang-cmdliner-err-runner" {>= "0.0.16"}
   "conf-git" {with-test}
   "conf-hg" {with-test}
   "fpath" {>= "0.7.3"}
   "fpath-sexp0" {>= "0.3.1"}
   "pp" {>= "2.0.0"}
-  "pplumbing" {>= "0.0.14"}
+  "pplumbing-err" {>= "0.0.16"}
+  "pplumbing-pp-tty" {>= "0.0.16"}
   "sexplib0" {>= "v0.16"}
   "volgo" {= version}
   "volgo-git-backend" {= version}

--- a/volgo.opam
+++ b/volgo.opam
@@ -15,7 +15,8 @@ depends: [
   "fpath" {>= "0.7.3"}
   "fpath-sexp0" {>= "0.3.1"}
   "pp" {>= "2.0.0"}
-  "pplumbing" {>= "0.0.14"}
+  "pplumbing-err" {>= "0.0.16"}
+  "pplumbing-pp-tty" {>= "0.0.16"}
   "sexplib0" {>= "v0.16"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
This isolates the dependencies which in turn reduces the overall dependencies of the vcs libraries by removing pplumbing transitive dependencies that are not required by the vcs libs.