### PR TITLE
Add constraint for cmdliner in tests

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -348,6 +348,8 @@
    (>= 0.0.9))
   (cmdlang-cmdliner-err-runner
    (>= 0.0.16))
+  (cmdliner
+   (< 2.0))
   conf-git
   conf-hg
   (core
@@ -461,6 +463,8 @@
    (>= 0.0.9))
   (cmdlang-cmdliner-err-runner
    (>= 0.0.16))
+  (cmdliner
+   (< 2.0))
   conf-git
   conf-hg
   (core

--- a/volgo-dev.opam
+++ b/volgo-dev.opam
@@ -19,6 +19,7 @@ depends: [
   "bitv" {>= "2.1"}
   "cmdlang" {>= "0.0.9"}
   "cmdlang-cmdliner-err-runner" {>= "0.0.16"}
+  "cmdliner" {< "2.0"}
   "conf-git"
   "conf-hg"
   "core" {>= "v0.17"}

--- a/volgo-tests.opam
+++ b/volgo-tests.opam
@@ -18,6 +18,7 @@ depends: [
   "bitv" {>= "2.1"}
   "cmdlang" {>= "0.0.9"}
   "cmdlang-cmdliner-err-runner" {>= "0.0.16"}
+  "cmdliner" {< "2.0"}
   "conf-git"
   "conf-hg"
   "core" {>= "v0.17"}


### PR DESCRIPTION
- Actual upgrade/cleanup required due to relying on unstable help expect trace.