### PR TITLE
Zanuda tweaks (refactors)

### DIFF
--- a/lib/volgo/src/graph.ml
+++ b/lib/volgo/src/graph.ml
@@ -235,8 +235,7 @@ let log_line t ~node = Node_kind.to_log_line t.$(node) ~f:(fun i -> Node_kind.re
    [visited] is taken as an input so we can re-use the same array multiple
    times, rather than re-allocating it. *)
 let iter_ancestors t ~visited node ~f =
-  let rec loop to_visit =
-    match to_visit with
+  let rec loop = function
     | [] -> ()
     | node :: to_visit ->
       let to_visit =
@@ -404,8 +403,7 @@ let roots t =
 let is_strict_ancestor_internal t ~ancestor ~descendant =
   assert (ancestor < descendant);
   let visited = Bitv.create (descendant - ancestor + 1) false in
-  let rec loop to_visit =
-    match to_visit with
+  let rec loop = function
     | [] -> false
     | node :: to_visit ->
       (match Int.compare ancestor node |> Ordering.of_int with

--- a/lib/volgo/src/import.ml
+++ b/lib/volgo/src/import.ml
@@ -145,12 +145,6 @@ module Int = struct
 
   let incr = incr
   let max_value = max_int
-
-  let of_string s =
-    try int_of_string s with
-    | _ -> failwith (Printf.sprintf "Int.of_string: %S" s)
-  ;;
-
   let of_string_opt = int_of_string_opt
 
   let to_string_hum n =

--- a/lib/volgo/src/import.mli
+++ b/lib/volgo/src/import.mli
@@ -63,7 +63,6 @@ module Int : sig
   val sexp_of_t : t -> Sexp.t
   val incr : int ref -> unit
   val max_value : int
-  val of_string : string -> int
   val of_string_opt : string -> int option
   val to_string_hum : int -> string
 end

--- a/lib/volgo_git_backend/src/name_status.ml
+++ b/lib/volgo_git_backend/src/name_status.ml
@@ -99,7 +99,18 @@ let parse_line_exn ~line : Vcs.Name_status.Change.t =
          | `M | `T -> Modified (Vcs.Path_in_repo.v path)
          | (`R | `C) as diff_status ->
            let similarity =
-             String.sub status ~pos:1 ~len:(String.length status - 1) |> Int.of_string
+             let data = String.sub status ~pos:1 ~len:(String.length status - 1) in
+             match Int.of_string_opt data with
+             | Some i -> i
+             | None ->
+               raise
+                 (Err.E
+                    (Err.create
+                       [ Pp.textf
+                           "Git diff status '%s' expected to be followed by an integer."
+                           (Diff_status.sexp_of_t diff_status |> Sexp.to_string_hum)
+                       ; Pp.textf "Data parsed was %S (not an int)." data
+                       ]))
            in
            let path2 =
              match List.hd rest with

--- a/lib/volgo_git_backend/test/test__name_status.ml
+++ b/lib/volgo_git_backend/test/test__name_status.ml
@@ -211,10 +211,12 @@ let%expect_test "parse_lines_exn" =
     ; "!\tfile8"
     ; "X\tfile9"
     ; "R\tfile10"
+    ; "Rbl\tfile10"
     ; "R35\tfile10"
     ; "R35\tfile1\tfile2"
     ; "T\tfile1"
     ; "C\tfile11"
+    ; "Cbl\tfile1"
     ; "C75\tfile1\tfile2"
     ; "Z\tfile12"
     ]
@@ -276,7 +278,16 @@ let%expect_test "parse_lines_exn" =
     ("R\tfile10" (
       Error (
         (context (Volgo_git_backend.Name_status.parse_line_exn (line "R\tfile10")))
-        (error (Failure "Int.of_string: \"\"")))))
+        (error
+         "Git diff status 'R' expected to be followed by an integer."
+         "Data parsed was \"\" (not an int)."))))
+    ("Rbl\tfile10" (
+      Error (
+        (context (
+          Volgo_git_backend.Name_status.parse_line_exn (line "Rbl\tfile10")))
+        (error
+         "Git diff status 'R' expected to be followed by an integer."
+         "Data parsed was \"bl\" (not an int)."))))
     ("R35\tfile10" (
       Error (
         (context (
@@ -292,7 +303,16 @@ let%expect_test "parse_lines_exn" =
     ("C\tfile11" (
       Error (
         (context (Volgo_git_backend.Name_status.parse_line_exn (line "C\tfile11")))
-        (error (Failure "Int.of_string: \"\"")))))
+        (error
+         "Git diff status 'C' expected to be followed by an integer."
+         "Data parsed was \"\" (not an int)."))))
+    ("Cbl\tfile1" (
+      Error (
+        (context (
+          Volgo_git_backend.Name_status.parse_line_exn (line "Cbl\tfile1")))
+        (error
+         "Git diff status 'C' expected to be followed by an integer."
+         "Data parsed was \"bl\" (not an int)."))))
     ("C75\tfile1\tfile2" (
       Ok (
         Copied

--- a/lib/volgo_git_eio/src/make_runtime.ml
+++ b/lib/volgo_git_eio/src/make_runtime.ml
@@ -237,10 +237,9 @@ let vcs_cli ~of_process_output ?env t ~cwd ~args ~f =
                 [ sexp_field (module String) "prog" prog
                 ; sexp_field' (List.sexp_of_t String.sexp_of_t) "args" args
                 ; sexp_field'
-                    (fun x ->
-                       match x with
-                       | #Exit_status.t as e -> Exit_status.sexp_of_t e
-                       | `Unknown -> Sexp.Atom "Unknown")
+                    (function
+                      | #Exit_status.t as e -> Exit_status.sexp_of_t e
+                      | `Unknown -> Sexp.Atom "Unknown")
                     "exit_status"
                     !exit_status_r
                 ; sexp_field (module String) "cwd" (snd cwd)


### PR DESCRIPTION
These changes were inspired by looking at Alerts raised by the [Zanuda](https://github.com/Kakadu/zanuda) OCaml linter.

One alert was pointing out the fact that the local re-implementation of `Int.of_string` would "swallow" exceptions. I found it best to remove this function and be explicit about the actual error at use-site, so this alert went away.

We didn't fix all the Alerts, rather chose to simply attend a couple obvious ones that seems applicable. Thanks Zanuda!

