### PR TITLE
Simplify opam dev dependencies

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -328,20 +328,12 @@
    (and
     (>= 5.2)
     (< 5.4~)))
-  (ocamlformat
-   (and
-    :with-dev-setup
-    (= 0.27.0)))
   (astring
    (>= 0.8.5))
   (base
    (>= v0.17))
   (base_quickcheck
    (>= v0.17))
-  (bisect_ppx
-   (and
-    :with-dev-setup
-    (>= 2.8.3)))
   (bitv
    (>= 2.1))
   (cmdlang
@@ -388,10 +380,6 @@
    (>= v0.17))
   (ppx_here
    (>= v0.17))
-  (ppx_js_style
-   (and
-    :with-dev-setup
-    (>= v0.17)))
   (ppx_let
    (>= v0.17))
   (ppx_sexp_conv
@@ -446,9 +434,7 @@
     (>= 5.3)
     (< 5.4~)))
   (ocamlformat
-   (and
-    :with-dev-setup
-    (= 0.27.0)))
+   (= 0.27.0))
   (astring
    (>= 0.8.5))
   (base
@@ -456,9 +442,7 @@
   (base_quickcheck
    (>= v0.17))
   (bisect_ppx
-   (and
-    :with-dev-setup
-    (>= 2.8.3)))
+   (>= 2.8.3))
   (bitv
    (>= 2.1))
   (cmdlang
@@ -504,9 +488,7 @@
   (ppx_here
    (>= v0.17))
   (ppx_js_style
-   (and
-    :with-dev-setup
-    (>= v0.17)))
+   (>= v0.17))
   (ppx_let
    (>= v0.17))
   (ppx_sexp_conv

--- a/volgo-dev.opam
+++ b/volgo-dev.opam
@@ -11,11 +11,11 @@ bug-reports: "https://github.com/mbarbin/vcs/issues"
 depends: [
   "dune" {>= "3.17"}
   "ocaml" {>= "5.3" & < "5.4~"}
-  "ocamlformat" {with-dev-setup & = "0.27.0"}
+  "ocamlformat" {= "0.27.0"}
   "astring" {>= "0.8.5"}
   "base" {>= "v0.17"}
   "base_quickcheck" {>= "v0.17"}
-  "bisect_ppx" {with-dev-setup & >= "2.8.3"}
+  "bisect_ppx" {>= "2.8.3"}
   "bitv" {>= "2.1"}
   "cmdlang" {>= "0.0.9"}
   "cmdlang-cmdliner-err-runner" {>= "0.0.16"}
@@ -38,7 +38,7 @@ depends: [
   "ppx_expect" {>= "v0.17"}
   "ppx_hash" {>= "v0.17"}
   "ppx_here" {>= "v0.17"}
-  "ppx_js_style" {with-dev-setup & >= "v0.17"}
+  "ppx_js_style" {>= "v0.17"}
   "ppx_let" {>= "v0.17"}
   "ppx_sexp_conv" {>= "v0.17"}
   "ppx_sexp_message" {>= "v0.17"}

--- a/volgo-tests.opam
+++ b/volgo-tests.opam
@@ -10,11 +10,9 @@ bug-reports: "https://github.com/mbarbin/vcs/issues"
 depends: [
   "dune" {>= "3.17"}
   "ocaml" {>= "5.2" & < "5.4~"}
-  "ocamlformat" {with-dev-setup & = "0.27.0"}
   "astring" {>= "0.8.5"}
   "base" {>= "v0.17"}
   "base_quickcheck" {>= "v0.17"}
-  "bisect_ppx" {with-dev-setup & >= "2.8.3"}
   "bitv" {>= "2.1"}
   "cmdlang" {>= "0.0.9"}
   "cmdlang-cmdliner-err-runner" {>= "0.0.16"}
@@ -37,7 +35,6 @@ depends: [
   "ppx_expect" {>= "v0.17"}
   "ppx_hash" {>= "v0.17"}
   "ppx_here" {>= "v0.17"}
-  "ppx_js_style" {with-dev-setup & >= "v0.17"}
   "ppx_let" {>= "v0.17"}
   "ppx_sexp_conv" {>= "v0.17"}
   "ppx_sexp_message" {>= "v0.17"}


### PR DESCRIPTION
In this repo we already have a -dev package to regroup dev dependencies. Thus:

- We do not need to have them listed as dev dependencies of other packages.
- There is no need to mark them as dev dependencies in the dev package itself.

This change fixes both.