### PR TITLE
Allow @, #, and / characters in tag names

### DIFF
--- a/src/volgo/tag_name.ml
+++ b/src/volgo/tag_name.ml
@@ -28,7 +28,10 @@ let invariant t =
     || Char.equal c '-'
     || Char.equal c '_'
     || Char.equal c '.'
-    || Char.equal c '+')
+    || Char.equal c '+'
+    || Char.equal c '@'
+    || Char.equal c '#'
+    || Char.equal c '/')
 ;;
 
 include Validated_string.Make (struct

--- a/test/volgo/test__tag_name.ml
+++ b/test/volgo/test__tag_name.ml
@@ -27,10 +27,16 @@ let%expect_test "of_string" =
   in
   test "no space";
   [%expect {| Error "\"no space\": invalid tag_name" |}];
-  test "slashes/are/not/allowed";
-  [%expect {| Error "\"slashes/are/not/allowed\": invalid tag_name" |}];
+  test "slashes/are/allowed";
+  [%expect {| slashes/are/allowed |}];
   test "dashes-and_underscores";
   [%expect {| dashes-and_underscores |}];
+  test "with@at";
+  [%expect {| with@at |}];
+  test "with#hash";
+  [%expect {| with#hash |}];
+  test "predicate@0.1.0";
+  [%expect {| predicate@0.1.0 |}];
   test "0.1.8";
   [%expect {| 0.1.8 |}];
   test "v0.1.8";


### PR DESCRIPTION
These characters are valid and used in real-world repositories (e.g., predicate@0.1.0, run/v1.15.0).