### PR TITLE
Change invalid graph invocation to raise internal code errors

### DIFF
--- a/src/volgo/graph.mli
+++ b/src/volgo/graph.mli
@@ -53,14 +53,23 @@ val create : unit -> t
     that already exists in the git log. *)
 
 (** [add t ~log] add to [t] all the nodes from the log. This is idempotent -
-    this doesn't add the nodes that [t] already knows. *)
+    this doesn't add the nodes that [t] already knows.
+
+    Raises [Code_error.E] if the log contains an internal consistency error
+    (e.g., a commit references a parent that doesn't exist in the log). This is
+    akin to [Invalid_argument] - it indicates a programming error that needs to
+    be fixed rather than an error condition to be handled at runtime. *)
 val add_nodes : t -> log:Log.t -> unit
 
-(** [set_refs t ~refs] add to [t] all the refs from the log. *)
-val set_refs : t -> refs:Refs.t -> unit
-
-(** Same as [set_refs], but one ref at a time. *)
+(** [set_ref t ~rev ~ref_kind] adds to [t] a ref from the log. Raises
+    [Code_error.E] if the [rev] is not known by the graph. This is akin to
+    [Invalid_argument] - it indicates a programming error that needs to be fixed
+    rather than an error condition to be handled at runtime. *)
 val set_ref : t -> rev:Rev.t -> ref_kind:Ref_kind.t -> unit
+
+(** [set_refs t ~refs] is a convenient wrapper for performing multiple [set_ref]
+    in one call. *)
+val set_refs : t -> refs:Refs.t -> unit
 
 (** {1 Nodes}
 
@@ -292,5 +301,9 @@ val summary : t -> Summary.t
     that take advantage of operations working on integers, if the rest of the
     exposed API isn't enough for your use case. *)
 
+(** Raises [Code_error.E] if the index is out of bounds. This is akin to
+    [Invalid_argument] - it indicates a programming error that needs to be
+    fixed rather than an error condition to be handled at runtime. *)
 val get_node_exn : t -> index:int -> Node.t
+
 val node_index : Node.t -> int

--- a/test/volgo/test__graph.ml
+++ b/test/volgo/test__graph.ml
@@ -514,7 +514,13 @@ let%expect_test "set invalid rev" =
       ~ref_kind:(Local_branch { branch_name = Vcs.Branch_name.v "main" })
   in
   require_does_raise (fun () -> set_ref_r1 ());
-  [%expect {| ("Rev not found." 5cd237e9598b11065c344d1eb33bc8c15cd237e9) |}];
+  [%expect
+    {|
+    ("Rev not found.",
+     { rev = "5cd237e9598b11065c344d1eb33bc8c15cd237e9"
+     ; ref_kind = Local_branch { branch_name = "main" }
+     })
+    |}];
   Vcs.Graph.add_nodes graph ~log:[ Line.root ~rev:r1 ];
   set_ref_r1 ();
   print_dyn (Vcs.Graph.refs graph |> Vcs.Refs.to_dyn);
@@ -1020,9 +1026,9 @@ let%expect_test "debug graph" =
   get_node_exn 4;
   [%expect {| "#4" |}];
   require_does_raise (fun () -> get_node_exn 50);
-  [%expect {| ("Node index out of bounds." ((index 50) (node_count 7))) |}];
+  [%expect {| ("Node index out of bounds.", { index = 50; node_count = 7 }) |}];
   require_does_raise (fun () -> get_node_exn (-1));
-  [%expect {| ("Node index out of bounds." ((index -1) (node_count 7))) |}];
+  [%expect {| ("Node index out of bounds.", { index = -1; node_count = 7 }) |}];
   (* Here we monitor for a regression of a bug where [set_ref] would not
      properly update pre-existing bindings. *)
   let upstream =


### PR DESCRIPTION
`Code_error.E` is akin to `Invalid_argument` and should be reserved for cases indicating a programming error that needs to be fixed in the code, rather than an exception that needs to be handled in a production path.

In this commit we change the semantic of a few of error conditions to be internal errors of the code error sort, rather than user facing errors.

This is breaking change as the nature of the exception that is raised changes. The goal is to help flush out bugs in user code and making usage more robust and correct by construction, with the hope that these should be caught during testing phases, or bug report that will be attended over time.